### PR TITLE
feat: add command service webhook plugin example

### DIFF
--- a/example/command-service-webhook-plugin.js
+++ b/example/command-service-webhook-plugin.js
@@ -1,0 +1,32 @@
+// ==WebhookPlugin==
+// @name         Command Service Bridge
+// @namespace    github.com/openilink
+// @version      1.0.0
+// @description  Forward WeChat text messages to an HTTP command service as {"command": "..."}
+// @author       Awsl
+// @license      MIT
+// @homepage     https://github.com/openilink/openilink-hub
+// @icon         🛰️
+// @match        text
+// @connect      bhwa233-api.vercel.app
+// @grant        skip
+// ==/WebhookPlugin==
+
+function onRequest(ctx) {
+  var command = (ctx.msg && ctx.msg.content) ? String(ctx.msg.content) : "";
+  command = command.replace(/^\s+|\s+$/g, "");
+
+  if (!command) {
+    skip();
+    return;
+  }
+
+  ctx.req.url = "https://bhwa233-api.vercel.app/api/command";
+  ctx.req.method = "POST";
+  ctx.req.headers = ctx.req.headers || {};
+  ctx.req.headers["accept"] = "application/json";
+  ctx.req.headers["Content-Type"] = "application/json";
+  ctx.req.body = JSON.stringify({
+    command: command
+  });
+}


### PR DESCRIPTION
## Summary
- add a webhook plugin example that forwards text messages to the configured command service endpoint
- map incoming text content to the JSON payload shape `{"command": "..."}`
- skip empty text messages to avoid sending empty commands

## Usage
After installing the plugin, sending `hp` will produce a request equivalent to:

```bash
curl -X POST "https://bhwa233-api.vercel.app/api/command" \
  -H "accept: application/json" \
  -H "Content-Type: application/json" \
  -d "{\"command\":\"hp\"}"
```
