### PR TITLE
fix：修改docker 镜像打包需要golang 版本大于 1.25的问题[go.mod requires go >= 1.25]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY web/ ./
 RUN npm run build
 
 # --- Build backend ---
-FROM golang:1.23-alpine AS backend
+FROM golang:1.26-alpine AS backend
 RUN apk add --no-cache git gcc musl-dev
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
低版本打包报错：0.072 go: go.mod requires go >= 1.25 (running go 1.23.12; GOTOOLCHAIN=local)
------
Dockerfile:14
--------------------
  12 |     WORKDIR /app
  13 |     COPY go.mod go.sum ./
  14 | >>> RUN go mod download
  15 |     COPY . .
  16 |     COPY --from=frontend /app/internal/web/dist ./internal/web/dist
提升了golang 基础镜像版本

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend build environment with a newer Go toolchain version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->