### PR TITLE
feat(web): 使用 shadcn Sidebar 重设计侧边栏

### DIFF
--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -1,8 +1,37 @@
 import { Outlet, useNavigate, Link, useLocation } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { LogOut, Github, Puzzle, Bot, LayoutDashboard, User, Shield, Bug, Store, FolderOpen, ShieldCheck, BarChart3, Users, Settings, Blocks, Sun, Moon } from "lucide-react";
+import {
+  LogOut, Github, Bot, LayoutDashboard, User, Bug, Store,
+  FolderOpen, ShieldCheck, BarChart3, Users, Settings, Blocks, Sun, Moon,
+  ChevronsUpDown,
+} from "lucide-react";
 import { api } from "../lib/api";
 import { useTheme } from "../lib/theme";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 
 export function Layout() {
   const navigate = useNavigate();
@@ -18,109 +47,221 @@ export function Layout() {
 
   const isAdmin = user.role === "admin" || user.role === "superadmin";
 
+  const roleLabel =
+    user.role === "superadmin" ? "超级管理员" : user.role === "admin" ? "管理员" : "成员";
+
   async function handleLogout() {
     await api.logout();
     navigate("/login", { replace: true });
   }
 
   function isActive(path: string) {
-    if (path === "/dashboard") return location.pathname === "/dashboard" || location.pathname.startsWith("/dashboard/bot/");
+    if (path === "/dashboard")
+      return location.pathname === "/dashboard" || location.pathname.startsWith("/dashboard/bot/");
     if (path === "/dashboard/apps") return location.pathname.startsWith("/dashboard/apps");
     return location.pathname === path;
   }
 
-  function navLink(path: string, label: string, icon: any, indent = false) {
-    const active = isActive(path);
-    const Icon = icon;
-    return (
-      <Link key={path} to={path}
-        className={`flex items-center gap-2 rounded-lg text-sm transition-colors ${indent ? "pl-9 pr-3 py-1.5" : "px-3 py-2"} ${
-          active ? "bg-secondary text-foreground font-medium" : "text-muted-foreground hover:text-foreground hover:bg-secondary/50"
-        }`}>
-        {!indent && <Icon className="w-4 h-4" />}
-        {label}
-      </Link>
-    );
-  }
-
-  function sectionLabel(label: string, icon: any) {
-    const Icon = icon;
-    return (
-      <div className="flex items-center gap-2 px-3 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wide">
-        <Icon className="w-3.5 h-3.5" />
-        {label}
-      </div>
-    );
-  }
-
   return (
-    <div className="h-screen flex">
-      <aside className="w-52 border-r flex flex-col shrink-0 h-screen sticky top-0">
+    <SidebarProvider>
+      <Sidebar collapsible="icon">
+
         {/* Logo */}
-        <div className="px-5 py-5 border-b shrink-0">
-          <Link to="/dashboard" className="flex items-center gap-2 hover:opacity-80">
-            <LayoutDashboard className="w-5 h-5 text-primary" />
-            <span className="font-semibold text-base tracking-tight">OpenILink Hub</span>
-          </Link>
-        </div>
+        <SidebarHeader>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild tooltip="OpenILink Hub">
+                <Link to="/dashboard">
+                  <LayoutDashboard />
+                  <span className="font-semibold tracking-tight">OpenILink Hub</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarHeader>
 
-        {/* Nav */}
-        <nav className="flex-1 px-2 py-3 space-y-0.5 overflow-y-auto">
-          {navLink("/dashboard", "Bot 管理", Bot)}
-          {navLink("/dashboard/apps", "App 管理", Blocks)}
+        <SidebarContent>
+          {/* 主导航 */}
+          <SidebarGroup>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild isActive={isActive("/dashboard")} tooltip="Bot 管理">
+                    <Link to="/dashboard">
+                      <Bot />
+                      <span>Bot 管理</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild isActive={isActive("/dashboard/apps")} tooltip="App 管理">
+                    <Link to="/dashboard/apps">
+                      <Blocks />
+                      <span>App 管理</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
 
-          {sectionLabel("Webhook 插件", Puzzle)}
-          {navLink("/dashboard/webhook-plugins", "市场", Store, true)}
-          {navLink("/dashboard/webhook-plugins/my", "我的插件", FolderOpen, true)}
-          {navLink("/dashboard/webhook-plugins/debug", "调试器", Bug, true)}
-          {isAdmin && navLink("/dashboard/webhook-plugins/review", "审核", ShieldCheck, true)}
-        </nav>
+          <SidebarSeparator />
 
-        {/* Bottom nav */}
-        <div className="border-t px-2 py-2 space-y-0.5 shrink-0">
-          {navLink("/dashboard/settings", "账号设置", User)}
-          {isAdmin && sectionLabel("系统管理", Shield)}
-          {isAdmin && navLink("/dashboard/admin", "概览", BarChart3, true)}
-          {isAdmin && navLink("/dashboard/admin/users", "用户管理", Users, true)}
-          {isAdmin && navLink("/dashboard/admin/config", "系统配置", Settings, true)}
-        </div>
+          {/* Webhook 插件 */}
+          <SidebarGroup>
+            <SidebarGroupLabel>Webhook 插件</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild isActive={isActive("/dashboard/webhook-plugins")} tooltip="市场">
+                    <Link to="/dashboard/webhook-plugins">
+                      <Store />
+                      <span>市场</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild isActive={isActive("/dashboard/webhook-plugins/my")} tooltip="我的插件">
+                    <Link to="/dashboard/webhook-plugins/my">
+                      <FolderOpen />
+                      <span>我的插件</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild isActive={isActive("/dashboard/webhook-plugins/debug")} tooltip="调试器">
+                    <Link to="/dashboard/webhook-plugins/debug">
+                      <Bug />
+                      <span>调试器</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                {isAdmin && (
+                  <SidebarMenuItem>
+                    <SidebarMenuButton asChild isActive={isActive("/dashboard/webhook-plugins/review")} tooltip="审核">
+                      <Link to="/dashboard/webhook-plugins/review">
+                        <ShieldCheck />
+                        <span>审核</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                )}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
 
-        {/* User */}
-        <div className="border-t px-3 py-3 space-y-2 shrink-0">
-          <div className="flex items-center gap-2 px-1">
-            <div className="w-7 h-7 rounded-full bg-secondary flex items-center justify-center text-xs font-medium">
-              {user.username.charAt(0).toUpperCase()}
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-xs font-medium truncate">{user.username}</p>
-              <p className="text-[10px] text-muted-foreground">{user.role === "superadmin" ? "超级管理员" : user.role === "admin" ? "管理员" : "成员"}</p>
-            </div>
+          {/* 系统管理（仅管理员） */}
+          {isAdmin && (
+            <>
+              <SidebarSeparator />
+              <SidebarGroup>
+                <SidebarGroupLabel>系统管理</SidebarGroupLabel>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild isActive={isActive("/dashboard/admin")} tooltip="概览">
+                        <Link to="/dashboard/admin">
+                          <BarChart3 />
+                          <span>概览</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild isActive={isActive("/dashboard/admin/users")} tooltip="用户管理">
+                        <Link to="/dashboard/admin/users">
+                          <Users />
+                          <span>用户管理</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild isActive={isActive("/dashboard/admin/config")} tooltip="系统配置">
+                        <Link to="/dashboard/admin/config">
+                          <Settings />
+                          <span>系统配置</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </SidebarGroup>
+            </>
+          )}
+        </SidebarContent>
+
+        {/* Footer：账号设置 + 用户菜单 */}
+        <SidebarFooter>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild isActive={isActive("/dashboard/settings")} tooltip="账号设置">
+                <Link to="/dashboard/settings">
+                  <User />
+                  <span>账号设置</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarSeparator className="mx-0" />
+            <SidebarMenuItem>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <SidebarMenuButton
+                    size="lg"
+                    tooltip={user.username}
+                    className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                  >
+                    <Avatar className="size-8 rounded-lg shrink-0">
+                      <AvatarFallback className="rounded-lg text-xs font-semibold bg-sidebar-primary text-sidebar-primary-foreground">
+                        {user.username.charAt(0).toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="flex flex-col gap-0.5 text-left leading-none min-w-0">
+                      <span className="text-sm font-medium truncate">{user.username}</span>
+                      <span className="text-xs text-muted-foreground truncate">{roleLabel}</span>
+                    </div>
+                    <ChevronsUpDown className="ml-auto shrink-0" />
+                  </SidebarMenuButton>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent side="top" align="end" className="w-56">
+                  <DropdownMenuItem asChild>
+                    <a
+                      href="https://github.com/openilink/openilink-hub"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <Github />
+                      GitHub
+                    </a>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+                  >
+                    {resolvedTheme === "dark" ? <Sun /> : <Moon />}
+                    切换主题
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={handleLogout}>
+                    <LogOut />
+                    退出登录
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarFooter>
+
+        <SidebarRail />
+      </Sidebar>
+
+      <SidebarInset>
+        <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
+          <SidebarTrigger className="-ml-1" />
+        </header>
+        <main className="flex-1 overflow-auto">
+          <div className="mx-auto max-w-6xl px-6 py-8 sm:px-8 sm:py-10 lg:px-10">
+            <Outlet />
           </div>
-          <div className="flex items-center gap-1">
-            <a href="https://github.com/openilink/openilink-hub" target="_blank" rel="noopener"
-              className="flex-1 flex items-center justify-center gap-1 text-xs text-muted-foreground hover:text-foreground py-1.5 rounded-lg hover:bg-secondary/50 transition-colors">
-              <Github className="w-3 h-3" /> GitHub
-            </a>
-            <button
-              onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-              className="flex items-center justify-center text-muted-foreground hover:text-foreground py-1 px-2 rounded hover:bg-secondary/50 transition-colors cursor-pointer"
-              aria-label="切换主题"
-            >
-              {resolvedTheme === "dark" ? <Sun className="w-3 h-3" /> : <Moon className="w-3 h-3" />}
-            </button>
-            <button onClick={handleLogout}
-              className="flex-1 flex items-center justify-center gap-1 text-xs text-muted-foreground hover:text-foreground py-1.5 rounded-lg hover:bg-secondary/50 transition-colors cursor-pointer">
-              <LogOut className="w-3 h-3" /> 退出
-            </button>
-          </div>
-        </div>
-      </aside>
-
-      <main className="flex-1 overflow-auto h-screen">
-        <div className="mx-auto max-w-6xl px-6 py-8 sm:px-8 sm:py-10 lg:px-10">
-          <Outlet />
-        </div>
-      </main>
-    </div>
+        </main>
+      </SidebarInset>
+    </SidebarProvider>
   );
 }

--- a/web/src/components/ui/avatar.tsx
+++ b/web/src/components/ui/avatar.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+  size?: "default" | "sm" | "lg"
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn(
+        "aspect-square size-full rounded-full object-cover",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground bg-blend-color ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarBadge,
+}

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,267 @@
+import * as React from "react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { CheckIcon, ChevronRightIcon } from "lucide-react"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        align={align}
+        className={cn("z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon
+          />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon
+          />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -1,0 +1,145 @@
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-background bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close data-slot="sheet-close" asChild>
+            <Button
+              variant="ghost"
+              className="absolute top-3 right-3"
+              size="icon-sm"
+            >
+              <XIcon
+              />
+              <span className="sr-only">Close</span>
+            </Button>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-0.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn(
+        "font-heading text-base font-medium text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -1,0 +1,702 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { useIsMobile } from "@/hooks/use-mobile"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { PanelLeftIcon } from "lucide-react"
+
+const SIDEBAR_COOKIE_NAME = "sidebar_state"
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
+const SIDEBAR_WIDTH = "16rem"
+const SIDEBAR_WIDTH_MOBILE = "18rem"
+const SIDEBAR_WIDTH_ICON = "3rem"
+const SIDEBAR_KEYBOARD_SHORTCUT = "b"
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed"
+  open: boolean
+  setOpen: (open: boolean) => void
+  openMobile: boolean
+  setOpenMobile: (open: boolean) => void
+  isMobile: boolean
+  toggleSidebar: () => void
+}
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null)
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext)
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.")
+  }
+
+  return context
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}) {
+  const isMobile = useIsMobile()
+  const [openMobile, setOpenMobile] = React.useState(false)
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(defaultOpen)
+  const open = openProp ?? _open
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === "function" ? value(open) : value
+      if (setOpenProp) {
+        setOpenProp(openState)
+      } else {
+        _setOpen(openState)
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+    },
+    [setOpenProp, open]
+  )
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
+  }, [isMobile, setOpen, setOpenMobile])
+
+  // Adds a keyboard shortcut to toggle the sidebar.
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault()
+        toggleSidebar()
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [toggleSidebar])
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? "expanded" : "collapsed"
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+  )
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <div
+        data-slot="sidebar-wrapper"
+        style={
+          {
+            "--sidebar-width": SIDEBAR_WIDTH,
+            "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+            ...style,
+          } as React.CSSProperties
+        }
+        className={cn(
+          "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </SidebarContext.Provider>
+  )
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  dir,
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right"
+  variant?: "sidebar" | "floating" | "inset"
+  collapsible?: "offcanvas" | "icon" | "none"
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          dir={dir}
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <div
+      className="group peer hidden text-sidebar-foreground md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "group-data-[collapsible=offcanvas]:w-0",
+          "group-data-[side=right]:rotate-180",
+          variant === "floating" || variant === "inset"
+            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        data-side={side}
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          // Adjust the padding for floating and inset variants.
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          className
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="flex size-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 group-data-[variant=floating]:ring-sidebar-border"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon-sm"
+      className={cn(className)}
+      onClick={(event) => {
+        onClick?.(event)
+        toggleSidebar()
+      }}
+      {...props}
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  )
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("h-8 w-full bg-background shadow-none", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        "no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupLabel({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "div"
+
+  return (
+    <Comp
+      data-slot="sidebar-group-label"
+      data-sidebar="group-label"
+      className={cn(
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupAction({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "button"
+
+  return (
+    <Comp
+      data-slot="sidebar-group-action"
+      data-sidebar="group-action"
+      className={cn(
+        "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-0.5", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function SidebarMenuButton({
+  asChild = false,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean
+  isActive?: boolean
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>
+} & VariantProps<typeof sidebarMenuButtonVariants>) {
+  const Comp = asChild ? Slot.Root : "button"
+  const { isMobile, state } = useSidebar()
+
+  const button = (
+    <Comp
+      data-slot="sidebar-menu-button"
+      data-sidebar="menu-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  )
+
+  if (!tooltip) {
+    return button
+  }
+
+  if (typeof tooltip === "string") {
+    tooltip = {
+      children: tooltip,
+    }
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  )
+}
+
+function SidebarMenuAction({
+  className,
+  asChild = false,
+  showOnHover = false,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean
+  showOnHover?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "button"
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-action"
+      data-sidebar="menu-action"
+      className={cn(
+        "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+        showOnHover &&
+          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-active/menu-button:text-sidebar-accent-foreground aria-expanded:opacity-100 md:opacity-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuBadge({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 peer-data-active/menu-button:text-sidebar-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean
+}) {
+  // Random width between 50 to 90%.
+  const [width] = React.useState(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`
+  })
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  )
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5 group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubButton({
+  asChild = false,
+  size = "md",
+  isActive = false,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean
+  size?: "sm" | "md"
+  isActive?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "a"
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-sub-button"
+      data-sidebar="menu-sub-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(
+        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+}

--- a/web/src/components/ui/skeleton.tsx
+++ b/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }

--- a/web/src/hooks/use-mobile.ts
+++ b/web/src/hooks/use-mobile.ts
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+const MOBILE_BREAKPOINT = 768
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return !!isMobile
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -15,10 +15,12 @@ import { PluginDebugPage } from "./pages/plugin-debug";
 import { AppsPage } from "./pages/apps";
 import { AppDetailPage } from "./pages/app-detail";
 import { ThemeProvider } from "./lib/theme";
+import { TooltipProvider } from "./components/ui/tooltip";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ThemeProvider>
+    <TooltipProvider>
     <BrowserRouter>
       <Routes>
         {/* Public */}
@@ -47,6 +49,7 @@ createRoot(document.getElementById("root")!).render(
         </Route>
       </Routes>
     </BrowserRouter>
+    </TooltipProvider>
     </ThemeProvider>
   </StrictMode>
 );

--- a/web/src/pages/admin.tsx
+++ b/web/src/pages/admin.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
-import { Card } from "../components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { api } from "../lib/api";
 import { Save, Trash2 } from "lucide-react";
 
@@ -72,7 +72,7 @@ function DashboardTab() {
         <div key={item.label} className="p-4 rounded-lg border bg-card text-center">
           <p className="text-2xl font-bold">{item.value}</p>
           <p className="text-xs text-muted-foreground">{item.label}</p>
-          {item.sub && <p className="text-[10px] text-muted-foreground mt-0.5">{item.sub}</p>}
+          {item.sub && <p className="text-xs text-muted-foreground mt-0.5">{item.sub}</p>}
         </div>
       ))}
     </div>
@@ -134,7 +134,7 @@ function UsersTab() {
           {showCreate ? "取消" : "创建用户"}
         </Button>
       </div>
-      {error && <p className="text-[10px] text-destructive">{error}</p>}
+      {error && <p className="text-xs text-destructive">{error}</p>}
 
       {showCreate && (
         <form onSubmit={handleCreate} className="p-3 rounded-lg border bg-card space-y-2">
@@ -146,7 +146,7 @@ function UsersTab() {
             <div className="flex gap-1">
               {["member", "admin"].map((r) => (
                 <button key={r} type="button" onClick={() => setNewRole(r)}
-                  className={`px-2 py-0.5 text-[10px] rounded cursor-pointer ${newRole === r ? "bg-primary text-primary-foreground" : "bg-secondary"}`}>
+                  className={`px-2 py-0.5 text-xs rounded cursor-pointer ${newRole === r ? "bg-primary text-primary-foreground" : "bg-secondary"}`}>
                   {r === "admin" ? "管理员" : "成员"}
                 </button>
               ))}
@@ -160,26 +160,26 @@ function UsersTab() {
         {users.map((u) => (
           <div key={u.id} className="flex items-center justify-between p-2.5 rounded-lg border bg-card">
             <div className="flex items-center gap-2">
-              <div className="w-7 h-7 rounded-full bg-secondary flex items-center justify-center text-[10px] font-medium">
+              <div className="w-7 h-7 rounded-full bg-secondary flex items-center justify-center text-xs font-medium">
                 {u.username.charAt(0).toUpperCase()}
               </div>
               <div>
                 <div className="flex items-center gap-1.5">
                   <span className="text-xs font-medium">{u.username}</span>
-                  <span className={`text-[10px] px-1 rounded ${u.role === "superadmin" ? "bg-yellow-500/10 text-yellow-600" : u.role === "admin" ? "bg-primary/10 text-primary" : "bg-secondary text-muted-foreground"}`}>
+                  <span className={`text-xs px-1 rounded ${u.role === "superadmin" ? "bg-yellow-500/10 text-yellow-600" : u.role === "admin" ? "bg-primary/10 text-primary" : "bg-secondary text-muted-foreground"}`}>
                     {u.role === "superadmin" ? "超级管理员" : u.role === "admin" ? "管理员" : "成员"}
                   </span>
-                  {u.status === "disabled" && <span className="text-[10px] px-1 rounded bg-destructive/10 text-destructive">已禁用</span>}
+                  {u.status === "disabled" && <span className="text-xs px-1 rounded bg-destructive/10 text-destructive">已禁用</span>}
                 </div>
-                {u.email && <p className="text-[10px] text-muted-foreground">{u.email}</p>}
+                {u.email && <p className="text-xs text-muted-foreground">{u.email}</p>}
               </div>
             </div>
             {u.role !== "superadmin" && (
               <div className="flex items-center gap-1">
-                <button onClick={() => handleToggleRole(u)} className="text-[10px] text-muted-foreground hover:text-foreground px-1.5 py-0.5 rounded hover:bg-secondary cursor-pointer">{u.role === "admin" ? "降级" : "升级"}</button>
-                <button onClick={() => handleToggleStatus(u)} className="text-[10px] text-muted-foreground hover:text-foreground px-1.5 py-0.5 rounded hover:bg-secondary cursor-pointer">{u.status === "active" ? "禁用" : "启用"}</button>
-                <button onClick={() => handleResetPassword(u)} className="text-[10px] text-muted-foreground hover:text-foreground px-1.5 py-0.5 rounded hover:bg-secondary cursor-pointer">重置密码</button>
-                <button onClick={() => handleDelete(u)} className="text-[10px] text-destructive px-1.5 py-0.5 rounded hover:bg-destructive/10 cursor-pointer">删除</button>
+                <button onClick={() => handleToggleRole(u)} className="text-xs text-muted-foreground hover:text-foreground px-1.5 py-0.5 rounded hover:bg-secondary cursor-pointer">{u.role === "admin" ? "降级" : "升级"}</button>
+                <button onClick={() => handleToggleStatus(u)} className="text-xs text-muted-foreground hover:text-foreground px-1.5 py-0.5 rounded hover:bg-secondary cursor-pointer">{u.status === "active" ? "禁用" : "启用"}</button>
+                <button onClick={() => handleResetPassword(u)} className="text-xs text-muted-foreground hover:text-foreground px-1.5 py-0.5 rounded hover:bg-secondary cursor-pointer">重置密码</button>
+                <button onClick={() => handleDelete(u)} className="text-xs text-destructive px-1.5 py-0.5 rounded hover:bg-destructive/10 cursor-pointer">删除</button>
               </div>
             )}
           </div>
@@ -225,21 +225,25 @@ function SystemSection() {
   if (!info) return null;
 
   return (
-    <Card className="space-y-2">
-      <h3 className="text-sm font-medium">服务状态</h3>
-      <div className="space-y-1.5">
-        {[
-          { label: "AI 服务", enabled: info.ai },
-          { label: "对象存储 (MinIO)", enabled: info.storage },
-        ].map((item) => (
-          <div key={item.label} className="flex items-center justify-between text-sm p-2 rounded-lg border bg-background">
-            <span className="text-xs">{item.label}</span>
-            <span className={`text-[10px] px-2 py-0.5 rounded ${item.enabled ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground"}`}>
-              {item.enabled ? "已启用" : "未配置"}
-            </span>
-          </div>
-        ))}
-      </div>
+    <Card>
+      <CardHeader>
+        <CardTitle>服务状态</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col gap-1.5">
+          {[
+            { label: "AI 服务", enabled: info.ai },
+            { label: "对象存储 (MinIO)", enabled: info.storage },
+          ].map((item) => (
+            <div key={item.label} className="flex items-center justify-between text-sm p-2 rounded-lg border bg-background">
+              <span className="text-xs">{item.label}</span>
+              <span className={`text-xs px-2 py-0.5 rounded ${item.enabled ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground"}`}>
+                {item.enabled ? "已启用" : "未配置"}
+              </span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
     </Card>
   );
 }
@@ -278,25 +282,35 @@ function AISection() {
   }
 
   return (
-    <Card className="space-y-3">
-      <div className="flex items-center justify-between">
-        <h3 className="text-sm font-medium">AI 配置</h3>
-        {configured && <Button variant="ghost" size="sm" onClick={async () => { if (confirm("删除全局 AI 配置？")) { await api.deleteAIConfig(); load(); } }}><Trash2 className="w-3.5 h-3.5 text-destructive" /></Button>}
-      </div>
-      <p className="text-[10px] text-muted-foreground">配置后渠道可选择「内置」模式，无需单独填写 API Key</p>
-      <Input placeholder="https://api.openai.com/v1" value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} className="h-8 text-xs font-mono" />
-      <div className="flex gap-2">
-        <Input type="password" placeholder={configured ? `已配置 (${config.api_key})，留空不变` : "API Key"} value={apiKey} onChange={(e) => setApiKey(e.target.value)} className="h-8 text-xs font-mono" />
-        <Input placeholder="模型名称" value={model} onChange={(e) => setModel(e.target.value)} className="h-8 text-xs font-mono w-40" />
-      </div>
-      <textarea placeholder="默认 System Prompt" value={systemPrompt} onChange={(e) => setSystemPrompt(e.target.value)} rows={3}
-        className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring resize-none" />
-      <div className="flex items-center gap-2">
-        <label className="text-[10px] text-muted-foreground">上下文消息数</label>
-        <Input type="number" value={maxHistory} onChange={(e) => setMaxHistory(parseInt(e.target.value) || 20)} className="h-8 text-xs w-20" min={1} max={100} />
-      </div>
-      {error && <p className="text-[10px] text-destructive">{error}</p>}
-      <div className="flex justify-end"><Button size="sm" onClick={handleSave} disabled={saving}>保存</Button></div>
+    <Card>
+      <CardHeader>
+        <CardTitle>AI 配置</CardTitle>
+        {configured && (
+          <div className="col-start-2 row-span-2 row-start-1 self-start justify-self-end">
+            <Button variant="ghost" size="sm" onClick={async () => { if (confirm("删除全局 AI 配置？")) { await api.deleteAIConfig(); load(); } }}>
+              <Trash2 className="text-destructive" />
+            </Button>
+          </div>
+        )}
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col gap-3">
+          <p className="text-xs text-muted-foreground">配置后渠道可选择「内置」模式，无需单独填写 API Key</p>
+          <Input placeholder="https://api.openai.com/v1" value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} className="font-mono" />
+          <div className="flex gap-2">
+            <Input type="password" placeholder={configured ? `已配置 (${config.api_key})，留空不变` : "API Key"} value={apiKey} onChange={(e) => setApiKey(e.target.value)} className="font-mono" />
+            <Input placeholder="模型名称" value={model} onChange={(e) => setModel(e.target.value)} className="font-mono w-40" />
+          </div>
+          <textarea placeholder="默认 System Prompt" value={systemPrompt} onChange={(e) => setSystemPrompt(e.target.value)} rows={3}
+            className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring resize-none" />
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-muted-foreground">上下文消息数</label>
+            <Input type="number" value={maxHistory} onChange={(e) => setMaxHistory(parseInt(e.target.value) || 20)} className="w-20" min={1} max={100} />
+          </div>
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          <div className="flex justify-end"><Button size="sm" onClick={handleSave} disabled={saving}>保存</Button></div>
+        </div>
+      </CardContent>
     </Card>
   );
 }
@@ -310,15 +324,21 @@ function OAuthSection() {
   const callbackBase = window.location.origin + "/api/auth/oauth/";
 
   return (
-    <Card className="space-y-3">
-      <h3 className="text-sm font-medium">OAuth 配置</h3>
-      <p className="text-[10px] text-muted-foreground">DB 配置优先于环境变量，无需重启服务。</p>
-      {error && <p className="text-xs text-destructive">{error}</p>}
-      {Object.keys(providerLabels).map((name) => (
-        <OAuthProviderForm key={name} name={name} label={providerLabels[name]} config={config[name]}
-          callbackURL={callbackBase + name + "/callback"} help={providerCallbackHelp[name]}
-          onSaved={loadConfig} onError={setError} />
-      ))}
+    <Card>
+      <CardHeader>
+        <CardTitle>OAuth 配置</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col gap-4">
+          <p className="text-xs text-muted-foreground">DB 配置优先于环境变量，无需重启服务。</p>
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          {Object.keys(providerLabels).map((name) => (
+            <OAuthProviderForm key={name} name={name} label={providerLabels[name]} config={config[name]}
+              callbackURL={callbackBase + name + "/callback"} help={providerCallbackHelp[name]}
+              onSaved={loadConfig} onError={setError} />
+          ))}
+        </div>
+      </CardContent>
     </Card>
   );
 }
@@ -347,7 +367,7 @@ function OAuthProviderForm({ name, label, config, callbackURL, help, onSaved, on
       <div className="flex items-center justify-between">
         <div>
           <span className="text-sm font-medium">{label}</span>
-          {enabled && <span className={`ml-2 text-[10px] px-1.5 py-0.5 rounded ${source === "db" ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground"}`}>{source === "db" ? "数据库" : "环境变量"}</span>}
+          {enabled && <span className={`ml-2 text-xs px-1.5 py-0.5 rounded ${source === "db" ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground"}`}>{source === "db" ? "数据库" : "环境变量"}</span>}
         </div>
         {source === "db" && (
           <Button variant="ghost" size="sm" onClick={async () => { if (confirm(`删除 ${label} OAuth？`)) { onError(""); try { await api.deleteOAuthConfig(name); onSaved(); } catch (e: any) { onError(e.message); } } }}>
@@ -358,7 +378,7 @@ function OAuthProviderForm({ name, label, config, callbackURL, help, onSaved, on
       <Input placeholder="Client ID" value={clientId} onChange={(e) => setClientId(e.target.value)} className="h-8 text-xs font-mono" />
       <Input type="password" placeholder={enabled ? "Client Secret（留空不变）" : "Client Secret"} value={clientSecret} onChange={(e) => setClientSecret(e.target.value)} className="h-8 text-xs font-mono" />
       <div className="flex items-center justify-between">
-        <div className="text-[10px] text-muted-foreground space-y-0.5">
+        <div className="text-xs text-muted-foreground space-y-0.5">
           <p>回调：<code className="select-all">{callbackURL}</code></p>
           <p>{help}</p>
         </div>

--- a/web/src/pages/app-detail.tsx
+++ b/web/src/pages/app-detail.tsx
@@ -124,8 +124,8 @@ function SettingsTab({ app, onUpdate }: { app: any; onUpdate: () => void }) {
           <Input placeholder="主页 URL" value={form.homepage} onChange={(e) => setForm((f) => ({ ...f, homepage: e.target.value }))} className="h-8 text-xs" />
           <div className="flex items-center justify-between">
             <div>
-              {error && <span className="text-[10px] text-destructive">{error}</span>}
-              {success && <span className="text-[10px] text-primary">{success}</span>}
+              {error && <span className="text-xs text-destructive">{error}</span>}
+              {success && <span className="text-xs text-primary">{success}</span>}
             </div>
             <Button type="submit" size="sm" disabled={saving}>{saving ? "..." : "保存"}</Button>
           </div>
@@ -182,7 +182,7 @@ function CommandsEditor({ app, onUpdate }: { app: any; onUpdate: () => void }) {
         </Button>
       </div>
       {commands.length === 0 && (
-        <p className="text-[10px] text-muted-foreground">暂无命令</p>
+        <p className="text-xs text-muted-foreground">暂无命令</p>
       )}
       {commands.map((cmd, i) => (
         <div key={i} className="flex items-start gap-2 p-2 rounded-lg border bg-background">
@@ -233,7 +233,7 @@ function EventsScopesTab({ app, onUpdate }: { app: any; onUpdate: () => void }) 
             <label key={et.key} className="flex items-center gap-2 cursor-pointer">
               <input type="checkbox" checked={events.includes(et.key)} onChange={() => toggleEvent(et.key)} className="w-3.5 h-3.5 accent-primary" />
               <span className="text-xs">{et.label}</span>
-              <span className="text-[10px] text-muted-foreground font-mono">{et.key}</span>
+              <span className="text-xs text-muted-foreground font-mono">{et.key}</span>
             </label>
           ))}
         </div>
@@ -247,7 +247,7 @@ function EventsScopesTab({ app, onUpdate }: { app: any; onUpdate: () => void }) 
             <label key={s.key} className="flex items-center gap-2 cursor-pointer">
               <input type="checkbox" checked={scopes.includes(s.key)} onChange={() => toggleScope(s.key)} className="w-3.5 h-3.5 accent-primary" />
               <span className="text-xs">{s.label}</span>
-              <span className="text-[10px] text-muted-foreground font-mono">{s.key}</span>
+              <span className="text-xs text-muted-foreground font-mono">{s.key}</span>
             </label>
           ))}
         </div>

--- a/web/src/pages/app-installation.tsx
+++ b/web/src/pages/app-installation.tsx
@@ -117,7 +117,7 @@ function InstallationConfig({ appId, installation, onUpdate, onBack }: { appId: 
             <ExternalLink className="w-3 h-3 mr-1" /> {verifying ? "..." : "验证 URL"}
           </Button>
           {verifyResult && (
-            <span className={`text-[10px] ${verifyResult.includes("成功") ? "text-primary" : "text-destructive"}`}>
+            <span className={`text-xs ${verifyResult.includes("成功") ? "text-primary" : "text-destructive"}`}>
               {verifyResult}
             </span>
           )}
@@ -199,11 +199,11 @@ function LogsView({ appId, installationId, type }: { appId: string; installation
   return (
     <div className="space-y-2">
       {type === "event" ? (
-        <div className="text-[10px] text-muted-foreground grid grid-cols-5 gap-2 px-2 font-medium">
+        <div className="text-xs text-muted-foreground grid grid-cols-5 gap-2 px-2 font-medium">
           <span>事件</span><span>状态</span><span>Trace ID</span><span>耗时</span><span>时间</span>
         </div>
       ) : (
-        <div className="text-[10px] text-muted-foreground grid grid-cols-5 gap-2 px-2 font-medium">
+        <div className="text-xs text-muted-foreground grid grid-cols-5 gap-2 px-2 font-medium">
           <span>方法</span><span>路径</span><span>状态</span><span>耗时</span><span>时间</span>
         </div>
       )}
@@ -215,19 +215,19 @@ function LogsView({ appId, installationId, type }: { appId: string; installation
               <Badge variant={log.status === "success" || log.status_code < 300 ? "default" : "destructive"} className="w-fit">
                 {log.status || log.status_code}
               </Badge>
-              <span className="font-mono truncate text-[10px]">{log.trace_id || "---"}</span>
+              <span className="font-mono truncate text-xs">{log.trace_id || "---"}</span>
               <span className="text-muted-foreground">{log.duration_ms != null ? `${log.duration_ms}ms` : "---"}</span>
-              <span className="text-muted-foreground text-[10px]">{log.created_at ? new Date(log.created_at * 1000).toLocaleString() : "---"}</span>
+              <span className="text-muted-foreground text-xs">{log.created_at ? new Date(log.created_at * 1000).toLocaleString() : "---"}</span>
             </>
           ) : (
             <>
               <span className="font-mono">{log.method}</span>
-              <span className="font-mono truncate text-[10px]">{log.path}</span>
+              <span className="font-mono truncate text-xs">{log.path}</span>
               <Badge variant={log.status_code < 300 ? "default" : "destructive"} className="w-fit">
                 {log.status_code}
               </Badge>
               <span className="text-muted-foreground">{log.duration_ms != null ? `${log.duration_ms}ms` : "---"}</span>
-              <span className="text-muted-foreground text-[10px]">{log.created_at ? new Date(log.created_at * 1000).toLocaleString() : "---"}</span>
+              <span className="text-muted-foreground text-xs">{log.created_at ? new Date(log.created_at * 1000).toLocaleString() : "---"}</span>
             </>
           )}
         </div>

--- a/web/src/pages/apps.tsx
+++ b/web/src/pages/apps.tsx
@@ -102,7 +102,7 @@ export function AppsPage() {
             />
             <div className="flex items-center justify-between">
               <div>
-                {error && <span className="text-[10px] text-destructive">{error}</span>}
+                {error && <span className="text-xs text-destructive">{error}</span>}
               </div>
               <Button type="submit" size="sm" disabled={saving}>{saving ? "..." : "创建"}</Button>
             </div>
@@ -134,7 +134,7 @@ export function AppsPage() {
           </div>
           <div className="flex items-center gap-2">
             {app.commands?.length > 0 && (
-              <span className="text-[10px] text-muted-foreground">{app.commands.length} 个命令</span>
+              <span className="text-xs text-muted-foreground">{app.commands.length} 个命令</span>
             )}
             <Badge variant={app.status === "active" ? "default" : "outline"}>
               {app.status === "active" ? "启用" : app.status || "草稿"}

--- a/web/src/pages/bot-detail.tsx
+++ b/web/src/pages/bot-detail.tsx
@@ -49,7 +49,7 @@ function ItemContent({ item, m, index }: { item: MessageItem; m: Message; index:
       <div className="space-y-1">
         <audio src={url} controls className="h-8" />
         {item.text && item.text !== "[voice]" && <p className="text-xs opacity-70">{item.text}</p>}
-        <div className="flex gap-2 text-[10px]">
+        <div className="flex gap-2 text-xs">
           <a href={url} download className="text-muted-foreground hover:text-primary">WAV</a>
           {silkUrl && <a href={silkUrl} download className="text-muted-foreground hover:text-primary">SILK</a>}
         </div>
@@ -97,7 +97,7 @@ function MessageContent({ m }: { m: Message }) {
             }}
           >重试</button>
         </div>
-        <p className="text-[10px] text-muted-foreground">CDN 链接可能已过期，需要对方重新发送</p>
+        <p className="text-xs text-muted-foreground">CDN 链接可能已过期，需要对方重新发送</p>
       </div>
     );
   }
@@ -372,7 +372,7 @@ export function BotDetailPage() {
                     isIn ? "bg-secondary rounded-bl-sm" : "bg-primary text-primary-foreground rounded-br-sm"
                   } ${m._sending ? "opacity-60" : ""}`}>
                     <MessageContent m={m} />
-                    <div className={`text-[10px] mt-1 ${isIn ? "text-muted-foreground" : "opacity-50"}`}>
+                    <div className={`text-xs mt-1 ${isIn ? "text-muted-foreground" : "opacity-50"}`}>
                       {m._sending ? "发送中..." : m._error ? (
                         <span className="text-destructive">
                           {m._error}
@@ -403,7 +403,7 @@ export function BotDetailPage() {
               )}
               <div className="flex-1 min-w-0">
                 <p className="text-xs truncate">{pendingFile.name}</p>
-                <p className="text-[10px] text-muted-foreground">{(pendingFile.size / 1024).toFixed(1)} KB</p>
+                <p className="text-xs text-muted-foreground">{(pendingFile.size / 1024).toFixed(1)} KB</p>
               </div>
               <Button size="sm" className="h-7" onClick={confirmFileSend} disabled={sending}>发送</Button>
               <Button size="sm" variant="ghost" className="h-7" onClick={cancelFile}>取消</Button>
@@ -463,7 +463,7 @@ function ChannelsTab({ botId, channels, onRefresh }: { botId: string; channels: 
             <Button type="submit" size="sm">创建</Button>
             <Button type="button" variant="ghost" size="sm" onClick={() => setCreating(false)}>取消</Button>
           </div>
-          <p className="text-[10px] text-muted-foreground">设置提及标识后，用户发送 @标识 的消息将定向路由到此通道</p>
+          <p className="text-xs text-muted-foreground">设置提及标识后，用户发送 @标识 的消息将定向路由到此通道</p>
         </form>
       ) : (
         <Button variant="outline" size="sm" onClick={() => setCreating(true)} className="w-full">
@@ -603,11 +603,11 @@ function ChannelCard({ botId, channel, onRefresh }: { botId: string; channel: an
           <Cable className="w-3.5 h-3.5 text-muted-foreground" />
           <span className="text-sm font-medium">{channel.name}</span>
           {channel.handle ? (
-            <span className="text-[10px] font-mono text-muted-foreground">@{channel.handle}</span>
+            <span className="text-xs font-mono text-muted-foreground">@{channel.handle}</span>
           ) : (
-            <span className="text-[10px] text-muted-foreground">全部消息</span>
+            <span className="text-xs text-muted-foreground">全部消息</span>
           )}
-          {!channel.enabled && <Badge variant="outline" className="text-[10px]">停用</Badge>}
+          {!channel.enabled && <Badge variant="outline" className="text-xs">停用</Badge>}
         </div>
         <Button variant="ghost" size="sm" onClick={(e) => {
           e.stopPropagation();
@@ -616,7 +616,7 @@ function ChannelCard({ botId, channel, onRefresh }: { botId: string; channel: an
           <Trash2 className="w-3.5 h-3.5 text-destructive" />
         </Button>
       </div>
-      <div className="flex items-center gap-2 mt-1.5 text-[10px] text-muted-foreground">
+      <div className="flex items-center gap-2 mt-1.5 text-xs text-muted-foreground">
         {hasWebhook && <span className="bg-primary/10 text-primary px-1.5 py-0.5 rounded flex items-center gap-0.5"><Webhook className="w-2.5 h-2.5" /> Webhook</span>}
         {hasPlugin && <span className="bg-primary/10 text-primary px-1.5 py-0.5 rounded flex items-center gap-0.5"><Puzzle className="w-2.5 h-2.5" /> 插件</span>}
         {aiEnabled && <span className="bg-primary/10 text-primary px-1.5 py-0.5 rounded flex items-center gap-0.5"><Bot className="w-2.5 h-2.5" /> AI</span>}
@@ -676,7 +676,7 @@ function ChannelRow({ botId, channel, onRefresh }: { botId: string; channel: any
                 value={handleVal}
                 onChange={(e) => setHandleVal(e.target.value)}
                 placeholder="handle"
-                className="h-5 text-[10px] w-24 px-1.5 font-mono"
+                className="h-5 text-xs w-24 px-1.5 font-mono"
                 autoFocus
                 onBlur={saveHandle}
               />
@@ -684,23 +684,23 @@ function ChannelRow({ botId, channel, onRefresh }: { botId: string; channel: any
           ) : (
             <button
               onClick={() => setEditingHandle(true)}
-              className="text-[10px] text-muted-foreground bg-secondary px-1.5 py-0.5 rounded cursor-pointer hover:bg-secondary/80"
+              className="text-xs text-muted-foreground bg-secondary px-1.5 py-0.5 rounded cursor-pointer hover:bg-secondary/80"
             >
               {channel.handle ? `@${channel.handle}` : "+ handle"}
             </button>
           )}
           {aiEnabled && (
-            <span className="text-[10px] text-primary bg-primary/10 px-1.5 py-0.5 rounded flex items-center gap-0.5">
+            <span className="text-xs text-primary bg-primary/10 px-1.5 py-0.5 rounded flex items-center gap-0.5">
               <Bot className="w-2.5 h-2.5" /> AI
             </span>
           )}
           {channel.webhook_config?.url && (
-            <span className="text-[10px] text-primary bg-primary/10 px-1.5 py-0.5 rounded flex items-center gap-0.5">
+            <span className="text-xs text-primary bg-primary/10 px-1.5 py-0.5 rounded flex items-center gap-0.5">
               <Webhook className="w-2.5 h-2.5" /> Webhook
             </span>
           )}
           {channel.webhook_config?.plugin_id && (
-            <span className="text-[10px] text-primary bg-primary/10 px-1.5 py-0.5 rounded flex items-center gap-0.5">
+            <span className="text-xs text-primary bg-primary/10 px-1.5 py-0.5 rounded flex items-center gap-0.5">
               <Puzzle className="w-2.5 h-2.5" /> 插件
             </span>
           )}
@@ -786,7 +786,7 @@ function AIConfigPanel({ botId, channelId, config, onSaved }: { botId: string; c
           <Bot className="w-3.5 h-3.5" /> AI 自动回复
         </span>
         <label className="flex items-center gap-1.5 cursor-pointer">
-          <span className="text-[10px] text-muted-foreground">{enabled ? "已开启" : "已关闭"}</span>
+          <span className="text-xs text-muted-foreground">{enabled ? "已开启" : "已关闭"}</span>
           <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} className="w-3.5 h-3.5 accent-primary" />
         </label>
       </div>
@@ -810,7 +810,7 @@ function AIConfigPanel({ botId, channelId, config, onSaved }: { botId: string; c
           </div>
 
           {source === "builtin" && (
-            <p className="text-[10px] text-muted-foreground">使用管理员在设置中配置的全局 AI 服务</p>
+            <p className="text-xs text-muted-foreground">使用管理员在设置中配置的全局 AI 服务</p>
           )}
 
           {source === "custom" && (
@@ -835,10 +835,10 @@ function AIConfigPanel({ botId, channelId, config, onSaved }: { botId: string; c
             className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-[11px] placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring resize-none"
           />
           <div className="flex items-center gap-2">
-            <label className="text-[10px] text-muted-foreground shrink-0">上下文消息数</label>
+            <label className="text-xs text-muted-foreground shrink-0">上下文消息数</label>
             <Input type="number" value={maxHistory} onChange={(e) => setMaxHistory(parseInt(e.target.value) || 20)} className="h-7 text-[11px] w-20" min={1} max={100} />
             <div className="flex-1" />
-            {error && <span className="text-[10px] text-destructive">{error}</span>}
+            {error && <span className="text-xs text-destructive">{error}</span>}
             <Button size="sm" className="h-7" onClick={handleSave} disabled={saving || !canSave}>{saving ? "..." : "保存"}</Button>
           </div>
         </div>
@@ -933,7 +933,7 @@ function WebhookPanel({ botId, channelId, config, onSaved }: {
         {/* Auth */}
         <div className="flex gap-1">
           {["", "bearer", "header", "hmac"].map((t) => (
-            <button key={t} onClick={() => setAuthType(t)} className={`px-2 py-0.5 text-[10px] rounded cursor-pointer transition-colors ${authType === t ? "bg-primary text-primary-foreground" : "bg-secondary text-secondary-foreground hover:bg-secondary/80"}`}>
+            <button key={t} onClick={() => setAuthType(t)} className={`px-2 py-0.5 text-xs rounded cursor-pointer transition-colors ${authType === t ? "bg-primary text-primary-foreground" : "bg-secondary text-secondary-foreground hover:bg-secondary/80"}`}>
               {t || "无认证"}
             </button>
           ))}
@@ -949,10 +949,10 @@ function WebhookPanel({ botId, channelId, config, onSaved }: {
 
         {/* Script source */}
         <div className="flex gap-1">
-          <button onClick={() => setScriptMode("plugin")} className={`px-2 py-0.5 text-[10px] rounded cursor-pointer transition-colors ${scriptMode === "plugin" ? "bg-primary text-primary-foreground" : "bg-secondary text-secondary-foreground hover:bg-secondary/80"}`}>
+          <button onClick={() => setScriptMode("plugin")} className={`px-2 py-0.5 text-xs rounded cursor-pointer transition-colors ${scriptMode === "plugin" ? "bg-primary text-primary-foreground" : "bg-secondary text-secondary-foreground hover:bg-secondary/80"}`}>
             插件市场
           </button>
-          <button onClick={() => setScriptMode("manual")} className={`px-2 py-0.5 text-[10px] rounded cursor-pointer transition-colors ${scriptMode === "manual" ? "bg-primary text-primary-foreground" : "bg-secondary text-secondary-foreground hover:bg-secondary/80"}`}>
+          <button onClick={() => setScriptMode("manual")} className={`px-2 py-0.5 text-xs rounded cursor-pointer transition-colors ${scriptMode === "manual" ? "bg-primary text-primary-foreground" : "bg-secondary text-secondary-foreground hover:bg-secondary/80"}`}>
             手动脚本
           </button>
         </div>
@@ -965,11 +965,11 @@ function WebhookPanel({ botId, channelId, config, onSaved }: {
                   <span>{pluginInfo.icon} </span>
                   <span className="font-medium">{pluginInfo.name}</span>
                   <span className="text-muted-foreground ml-1">v{pluginInfo.version}</span>
-                  <p className="text-[10px] text-muted-foreground mt-0.5">{pluginInfo.description}</p>
+                  <p className="text-xs text-muted-foreground mt-0.5">{pluginInfo.description}</p>
                 </div>
                 <div className="flex gap-1">
-                  <Button variant="ghost" size="sm" className="h-6 text-[10px]" onClick={() => setShowPluginPicker(true)}>更换</Button>
-                  <Button variant="ghost" size="sm" className="h-6 text-[10px] text-destructive" onClick={handleUninstallPlugin}>卸载</Button>
+                  <Button variant="ghost" size="sm" className="h-6 text-xs" onClick={() => setShowPluginPicker(true)}>更换</Button>
+                  <Button variant="ghost" size="sm" className="h-6 text-xs text-destructive" onClick={handleUninstallPlugin}>卸载</Button>
                 </div>
               </div>
             ) : (
@@ -980,14 +980,14 @@ function WebhookPanel({ botId, channelId, config, onSaved }: {
 
             {showPluginPicker && (
               <div className="border rounded p-2 space-y-1 max-h-40 overflow-y-auto bg-card">
-                {plugins.length === 0 && <p className="text-[10px] text-muted-foreground text-center py-2">暂无可用插件</p>}
+                {plugins.length === 0 && <p className="text-xs text-muted-foreground text-center py-2">暂无可用插件</p>}
                 {plugins.map((p) => (
                   <button key={p.id} onClick={() => handleInstallPlugin(p.id)} className="w-full text-left p-1.5 rounded hover:bg-secondary cursor-pointer text-xs flex items-center justify-between">
                     <span>{p.icon} {p.name} <span className="text-muted-foreground">v{p.version}</span></span>
-                    <span className="text-[10px] text-muted-foreground">{p.install_count} 安装</span>
+                    <span className="text-xs text-muted-foreground">{p.install_count} 安装</span>
                   </button>
                 ))}
-                <button onClick={() => setShowPluginPicker(false)} className="w-full text-center text-[10px] text-muted-foreground hover:text-primary cursor-pointer py-1">取消</button>
+                <button onClick={() => setShowPluginPicker(false)} className="w-full text-center text-xs text-muted-foreground hover:text-primary cursor-pointer py-1">取消</button>
               </div>
             )}
           </div>
@@ -1004,9 +1004,9 @@ function WebhookPanel({ botId, channelId, config, onSaved }: {
         )}
       </div>
       <div className="flex items-center justify-between">
-        <p className="text-[10px] text-muted-foreground">收到消息时 POST 到此 URL。</p>
+        <p className="text-xs text-muted-foreground">收到消息时 POST 到此 URL。</p>
         <div className="flex items-center gap-2">
-          {error && <span className="text-[10px] text-destructive">{error}</span>}
+          {error && <span className="text-xs text-destructive">{error}</span>}
           <Button size="sm" className="h-7" onClick={handleSave} disabled={saving}>{saving ? "..." : "保存"}</Button>
         </div>
       </div>
@@ -1106,7 +1106,7 @@ function LivePanel({ wsUrl, onClose }: { wsUrl: string; onClose: () => void }) {
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-1.5 border-b bg-secondary/30">
         <div className="flex items-center gap-2">
-          <span className={`text-[10px] font-medium ${statusColor}`}>
+          <span className={`text-xs font-medium ${statusColor}`}>
             {status === "connected" ? "LIVE" : status === "connecting" ? "CONNECTING" : "DISCONNECTED"}
           </span>
         </div>
@@ -1145,7 +1145,7 @@ function LogEntry({ log }: { log: WsLogEntry }) {
 
   if (log.dir === "sys") {
     return (
-      <div className="text-muted-foreground text-center text-[10px] py-0.5">
+      <div className="text-muted-foreground text-center text-xs py-0.5">
         — {log.type} {log.time} —
       </div>
     );
@@ -1200,13 +1200,13 @@ function LogEntry({ log }: { log: WsLogEntry }) {
         className={`flex items-start gap-1.5 ${hasDetail ? "cursor-pointer" : ""} hover:bg-secondary/30 rounded px-1 -mx-1`}
         onClick={() => hasDetail && setExpanded(!expanded)}
       >
-        <span className="text-muted-foreground shrink-0 w-14 text-[10px] pt-px">{log.time}</span>
+        <span className="text-muted-foreground shrink-0 w-14 text-xs pt-px">{log.time}</span>
         <span className={`shrink-0 ${dirColor}`}>{dirIcon}</span>
         <span className="text-primary shrink-0 font-medium">{log.type}</span>
         <span className="text-foreground truncate">{summary}</span>
       </div>
       {expanded && d != null && (
-        <pre className="ml-[70px] text-[10px] text-muted-foreground bg-secondary/30 rounded p-2 mt-0.5 mb-1 overflow-x-auto whitespace-pre-wrap break-all">
+        <pre className="ml-[70px] text-xs text-muted-foreground bg-secondary/30 rounded p-2 mt-0.5 mb-1 overflow-x-auto whitespace-pre-wrap break-all">
           {JSON.stringify(d, null, 2)}
         </pre>
       )}
@@ -1217,8 +1217,8 @@ function LogEntry({ log }: { log: WsLogEntry }) {
 function CopyRow({ label, value, copied, onCopy }: { label: string; value: string; copied: boolean; onCopy: () => void }) {
   return (
     <div className="flex items-center gap-2">
-      <span className="text-[10px] text-muted-foreground w-16 shrink-0">{label}</span>
-      <code className="flex-1 text-[10px] text-muted-foreground font-mono bg-background border rounded px-2 py-1 truncate select-all">
+      <span className="text-xs text-muted-foreground w-16 shrink-0">{label}</span>
+      <code className="flex-1 text-xs text-muted-foreground font-mono bg-background border rounded px-2 py-1 truncate select-all">
         {value}
       </code>
       <button onClick={onCopy} className="cursor-pointer text-muted-foreground hover:text-foreground shrink-0">
@@ -1274,7 +1274,7 @@ function BotSettingsTab({ bot, onUpdate }: { bot: any; onUpdate: () => void }) {
               />
               <span className="text-xs text-muted-foreground">小时后提醒</span>
             </div>
-            <p className="text-[10px] text-muted-foreground">
+            <p className="text-xs text-muted-foreground">
               设为 {reminderHours} 小时：Bot 静默 {reminderHours} 小时后发送提醒，距 24 小时过期还剩约 {Math.max(1, 24 - reminderHours)} 小时。建议设为 23 小时（提前 1 小时提醒）。
             </p>
           </>

--- a/web/src/pages/bots.tsx
+++ b/web/src/pages/bots.tsx
@@ -143,7 +143,7 @@ function BotCard({ bot, channelCount, onRefresh }: { bot: any; channelCount: num
         <div className="flex items-center gap-2 mt-1">
           <span className="text-xs text-muted-foreground">{channelCount} 个通道</span>
           {bot.status === "session_expired" && (
-            <span className="text-[10px] text-destructive">会话过期，请重新扫码绑定</span>
+            <span className="text-xs text-destructive">会话过期，请重新扫码绑定</span>
           )}
         </div>
       </div>

--- a/web/src/pages/channel-detail.tsx
+++ b/web/src/pages/channel-detail.tsx
@@ -129,26 +129,26 @@ function OverviewTab({ channel, botId, onRefresh }: { channel: any; botId: strin
       <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
         {cards.map((c) => (
           <div key={c.label} className="p-3 rounded-lg border bg-card cursor-pointer hover:border-primary/50" onClick={c.action}>
-            <p className="text-[10px] text-muted-foreground">{c.label}</p>
+            <p className="text-xs text-muted-foreground">{c.label}</p>
             <p className="text-sm font-medium mt-0.5">{c.value}</p>
           </div>
         ))}
         <CopyCard label="API Key" value={channel.api_key} />
         {channel.ai_config?.enabled && (
           <div className="p-3 rounded-lg border bg-card">
-            <p className="text-[10px] text-muted-foreground">AI 回复</p>
+            <p className="text-xs text-muted-foreground">AI 回复</p>
             <p className="text-sm font-medium mt-0.5 flex items-center gap-1"><Bot className="w-3 h-3" /> {channel.ai_config.source === "builtin" ? "内置" : "自定义"}</p>
           </div>
         )}
         {channel.webhook_config?.url && (
           <div className="p-3 rounded-lg border bg-card">
-            <p className="text-[10px] text-muted-foreground">Webhook</p>
+            <p className="text-xs text-muted-foreground">Webhook</p>
             <p className="text-sm font-mono mt-0.5 truncate">{channel.webhook_config.url}</p>
           </div>
         )}
         {pluginInfo && (
           <div className="p-3 rounded-lg border bg-card">
-            <p className="text-[10px] text-muted-foreground">插件</p>
+            <p className="text-xs text-muted-foreground">插件</p>
             <p className="text-sm font-medium mt-0.5">{pluginInfo.icon} {pluginInfo.name} v{pluginInfo.version}</p>
           </div>
         )}
@@ -182,7 +182,7 @@ function CopyCard({ label, value }: { label: string; value: string }) {
   }
   return (
     <div className="p-3 rounded-lg border bg-card cursor-pointer hover:border-primary/50" onClick={copy}>
-      <p className="text-[10px] text-muted-foreground">{label} {copied && <Check className="w-3 h-3 inline text-primary" />}</p>
+      <p className="text-xs text-muted-foreground">{label} {copied && <Check className="w-3 h-3 inline text-primary" />}</p>
       <p className="text-xs font-mono mt-0.5 truncate">{value}</p>
     </div>
   );
@@ -208,13 +208,13 @@ function ConnectTab({ channel }: { channel: any }) {
 
         <div>
           <p className="font-medium text-foreground mt-3 mb-1">WebSocket 连接</p>
-          <pre className="bg-background p-2 rounded overflow-x-auto text-[10px]">{`ws://${location.host}/api/v1/channels/connect?key=API_KEY`}</pre>
+          <pre className="bg-background p-2 rounded overflow-x-auto text-xs">{`ws://${location.host}/api/v1/channels/connect?key=API_KEY`}</pre>
           <p className="mt-1">连接后自动收到 init 消息，收到新消息时推送 message 事件。</p>
         </div>
 
         <div>
           <p className="font-medium text-foreground mt-3 mb-1">HTTP API</p>
-          <pre className="bg-background p-2 rounded overflow-x-auto text-[10px]">{`# 拉取消息
+          <pre className="bg-background p-2 rounded overflow-x-auto text-xs">{`# 拉取消息
 GET /api/v1/channels/messages?key=KEY&limit=50
 
 # 发送消息
@@ -234,7 +234,7 @@ function CopyField({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex items-center gap-2">
       <span className="text-xs text-muted-foreground w-16 shrink-0">{label}</span>
-      <code className="flex-1 text-[10px] font-mono bg-card border rounded px-2 py-1 truncate select-all">{value}</code>
+      <code className="flex-1 text-xs font-mono bg-card border rounded px-2 py-1 truncate select-all">{value}</code>
       <button onClick={() => { navigator.clipboard.writeText(value); setCopied(true); setTimeout(() => setCopied(false), 2000); }} className="cursor-pointer text-muted-foreground hover:text-foreground shrink-0">
         {copied ? <Check className="w-3 h-3 text-primary" /> : <Copy className="w-3 h-3" />}
       </button>
@@ -305,10 +305,10 @@ function WebhookTab({ channel, botId, onRefresh }: { channel: any; botId: string
 
       {/* Auth */}
       <div>
-        <p className="text-[10px] text-muted-foreground mb-1">认证方式</p>
+        <p className="text-xs text-muted-foreground mb-1">认证方式</p>
         <div className="flex gap-1">
           {["", "bearer", "header", "hmac"].map((t) => (
-            <button key={t} onClick={() => setAuthType(t)} className={`px-2 py-0.5 text-[10px] rounded cursor-pointer ${authType === t ? "bg-primary text-primary-foreground" : "bg-secondary"}`}>
+            <button key={t} onClick={() => setAuthType(t)} className={`px-2 py-0.5 text-xs rounded cursor-pointer ${authType === t ? "bg-primary text-primary-foreground" : "bg-secondary"}`}>
               {t || "无"}
             </button>
           ))}
@@ -325,10 +325,10 @@ function WebhookTab({ channel, botId, onRefresh }: { channel: any; botId: string
 
       {/* Script source */}
       <div>
-        <p className="text-[10px] text-muted-foreground mb-1">脚本来源</p>
+        <p className="text-xs text-muted-foreground mb-1">脚本来源</p>
         <div className="flex gap-1">
-          <button onClick={() => setScriptMode("plugin")} className={`px-2 py-0.5 text-[10px] rounded cursor-pointer ${scriptMode === "plugin" ? "bg-primary text-primary-foreground" : "bg-secondary"}`}>插件市场</button>
-          <button onClick={() => setScriptMode("manual")} className={`px-2 py-0.5 text-[10px] rounded cursor-pointer ${scriptMode === "manual" ? "bg-primary text-primary-foreground" : "bg-secondary"}`}>手动脚本</button>
+          <button onClick={() => setScriptMode("plugin")} className={`px-2 py-0.5 text-xs rounded cursor-pointer ${scriptMode === "plugin" ? "bg-primary text-primary-foreground" : "bg-secondary"}`}>插件市场</button>
+          <button onClick={() => setScriptMode("manual")} className={`px-2 py-0.5 text-xs rounded cursor-pointer ${scriptMode === "manual" ? "bg-primary text-primary-foreground" : "bg-secondary"}`}>手动脚本</button>
         </div>
       </div>
 
@@ -342,11 +342,11 @@ function WebhookTab({ channel, botId, onRefresh }: { channel: any; botId: string
                     <div className="flex items-center gap-1.5">
                       {pluginInfo.icon && <span className="text-base">{pluginInfo.icon}</span>}
                       <span className="text-xs font-medium">{pluginInfo.name}</span>
-                      <span className="text-[10px] text-muted-foreground">v{pluginInfo.version}</span>
-                      {pluginInfo.license && <span className="text-[10px] text-muted-foreground">{pluginInfo.license}</span>}
+                      <span className="text-xs text-muted-foreground">v{pluginInfo.version}</span>
+                      {pluginInfo.license && <span className="text-xs text-muted-foreground">{pluginInfo.license}</span>}
                     </div>
-                    <p className="text-[10px] text-muted-foreground mt-0.5">{pluginInfo.description}</p>
-                    <div className="flex items-center gap-2 mt-1 text-[10px] text-muted-foreground">
+                    <p className="text-xs text-muted-foreground mt-0.5">{pluginInfo.description}</p>
+                    <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
                       <span>by {pluginInfo.author || "anonymous"}</span>
                       <span>{pluginInfo.install_count} 安装</span>
                       {pluginInfo.namespace && <span className="font-mono">{pluginInfo.namespace}</span>}
@@ -354,19 +354,19 @@ function WebhookTab({ channel, botId, onRefresh }: { channel: any; botId: string
                   </div>
                 </div>
                 {/* Permissions summary */}
-                <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <span>@grant: {pluginInfo.grant_perms || "none"}</span>
                   <span>@match: {pluginInfo.match_types || "*"}</span>
                   {pluginInfo.connect_domains && pluginInfo.connect_domains !== "*" && <span>@connect: {pluginInfo.connect_domains}</span>}
                 </div>
-                {pluginInfo.changelog && <p className="text-[10px] text-muted-foreground">更新: {pluginInfo.changelog}</p>}
+                {pluginInfo.changelog && <p className="text-xs text-muted-foreground">更新: {pluginInfo.changelog}</p>}
               </div>
               <div className="border-t px-3 py-1.5 flex items-center gap-2">
-                <a href={`/dashboard/webhook-plugins/debug?plugin=${pluginId}`} className="text-[10px] text-primary hover:underline">调试</a>
-                {pluginInfo.github_url && <a href={pluginInfo.github_url} target="_blank" rel="noopener" className="text-[10px] text-primary hover:underline">GitHub</a>}
+                <a href={`/dashboard/webhook-plugins/debug?plugin=${pluginId}`} className="text-xs text-primary hover:underline">调试</a>
+                {pluginInfo.github_url && <a href={pluginInfo.github_url} target="_blank" rel="noopener" className="text-xs text-primary hover:underline">GitHub</a>}
                 <div className="ml-auto flex gap-1">
-                  <Button variant="ghost" size="sm" className="h-6 text-[10px]" onClick={() => setShowPicker(true)}>更换</Button>
-                  <Button variant="ghost" size="sm" className="h-6 text-[10px] text-destructive" onClick={() => { setPluginId(""); setVersionId(""); setPluginInfo(null); setScriptMode("manual"); }}>卸载</Button>
+                  <Button variant="ghost" size="sm" className="h-6 text-xs" onClick={() => setShowPicker(true)}>更换</Button>
+                  <Button variant="ghost" size="sm" className="h-6 text-xs text-destructive" onClick={() => { setPluginId(""); setVersionId(""); setPluginInfo(null); setScriptMode("manual"); }}>卸载</Button>
                 </div>
               </div>
             </div>
@@ -377,14 +377,14 @@ function WebhookTab({ channel, botId, onRefresh }: { channel: any; botId: string
           )}
           {showPicker && (
             <div className="border rounded p-2 space-y-1 max-h-48 overflow-y-auto bg-card">
-              {plugins.length === 0 && <p className="text-[10px] text-muted-foreground text-center py-2">暂无可用插件</p>}
+              {plugins.length === 0 && <p className="text-xs text-muted-foreground text-center py-2">暂无可用插件</p>}
               {plugins.map((p) => (
                 <button key={p.id} onClick={() => installPlugin(p.id)} className="w-full text-left p-1.5 rounded hover:bg-secondary cursor-pointer text-xs flex items-center justify-between">
                   <span>{p.icon} {p.name} <span className="text-muted-foreground">v{p.version}</span></span>
-                  <span className="text-[10px] text-muted-foreground">{p.install_count} 安装</span>
+                  <span className="text-xs text-muted-foreground">{p.install_count} 安装</span>
                 </button>
               ))}
-              <button onClick={() => setShowPicker(false)} className="w-full text-center text-[10px] text-muted-foreground hover:text-primary cursor-pointer py-1">取消</button>
+              <button onClick={() => setShowPicker(false)} className="w-full text-center text-xs text-muted-foreground hover:text-primary cursor-pointer py-1">取消</button>
             </div>
           )}
         </div>
@@ -401,7 +401,7 @@ function WebhookTab({ channel, botId, onRefresh }: { channel: any; botId: string
       )}
 
       <div className="flex items-center justify-between">
-        {error && <span className="text-[10px] text-destructive">{error}</span>}
+        {error && <span className="text-xs text-destructive">{error}</span>}
         <div className="ml-auto"><Button size="sm" onClick={handleSave} disabled={saving}>{saving ? "..." : "保存"}</Button></div>
       </div>
     </div>
@@ -442,8 +442,8 @@ function AITab({ channel, botId, onRefresh }: { channel: any; botId: string; onR
       {enabled && (
         <>
           <div className="flex gap-1">
-            <button onClick={() => setSource("builtin")} className={`px-2 py-0.5 text-[10px] rounded cursor-pointer ${source === "builtin" ? "bg-primary text-primary-foreground" : "bg-secondary"}`}>内置（全局配置）</button>
-            <button onClick={() => setSource("custom")} className={`px-2 py-0.5 text-[10px] rounded cursor-pointer ${source === "custom" ? "bg-primary text-primary-foreground" : "bg-secondary"}`}>自定义</button>
+            <button onClick={() => setSource("builtin")} className={`px-2 py-0.5 text-xs rounded cursor-pointer ${source === "builtin" ? "bg-primary text-primary-foreground" : "bg-secondary"}`}>内置（全局配置）</button>
+            <button onClick={() => setSource("custom")} className={`px-2 py-0.5 text-xs rounded cursor-pointer ${source === "custom" ? "bg-primary text-primary-foreground" : "bg-secondary"}`}>自定义</button>
           </div>
           {source === "custom" && (
             <div className="space-y-2">
@@ -462,7 +462,7 @@ function AITab({ channel, botId, onRefresh }: { channel: any; botId: string; onR
             className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-[11px] placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring resize-none"
           />
           <div className="flex items-center gap-2">
-            <label className="text-[10px] text-muted-foreground">上下文消息数</label>
+            <label className="text-xs text-muted-foreground">上下文消息数</label>
             <Input type="number" value={maxHistory} onChange={(e) => setMaxHistory(parseInt(e.target.value) || 20)} className="h-7 text-xs w-20" min={1} max={100} />
           </div>
         </>
@@ -505,15 +505,15 @@ function FilterTab({ channel, botId, onRefresh }: { channel: any; botId: string;
       <p className="text-xs text-muted-foreground">留空表示不过滤（接收所有消息）。多个值用逗号分隔。</p>
       <div className="space-y-2">
         <div>
-          <label className="text-[10px] text-muted-foreground">用户 ID 白名单</label>
+          <label className="text-xs text-muted-foreground">用户 ID 白名单</label>
           <Input value={userIds} onChange={(e) => setUserIds(e.target.value)} placeholder="user1@wx, user2@wx" className="h-7 text-[11px] font-mono" />
         </div>
         <div>
-          <label className="text-[10px] text-muted-foreground">关键词匹配</label>
+          <label className="text-xs text-muted-foreground">关键词匹配</label>
           <Input value={keywords} onChange={(e) => setKeywords(e.target.value)} placeholder="help, urgent" className="h-7 text-[11px] font-mono" />
         </div>
         <div>
-          <label className="text-[10px] text-muted-foreground">消息类型</label>
+          <label className="text-xs text-muted-foreground">消息类型</label>
           <Input value={msgTypes} onChange={(e) => setMsgTypes(e.target.value)} placeholder="text, image, voice, video, file" className="h-7 text-[11px] font-mono" />
         </div>
       </div>
@@ -554,13 +554,13 @@ function LiveTab({ channel }: { channel: any }) {
         <Radio className={`w-3 h-3 ${status === "connected" ? "text-primary" : "text-muted-foreground"}`} />
         <span className="text-xs">{status === "connected" ? "已连接" : status === "connecting" ? "连接中..." : "已断开"}</span>
         {logs.length > 0 && (
-          <button onClick={() => setLogs([])} className="text-[10px] text-muted-foreground hover:text-primary cursor-pointer ml-auto">清空</button>
+          <button onClick={() => setLogs([])} className="text-xs text-muted-foreground hover:text-primary cursor-pointer ml-auto">清空</button>
         )}
       </div>
       <div className="border rounded-lg bg-card p-2 max-h-96 overflow-y-auto space-y-1">
-        {logs.length === 0 && <p className="text-[10px] text-muted-foreground text-center py-4">等待消息...</p>}
+        {logs.length === 0 && <p className="text-xs text-muted-foreground text-center py-4">等待消息...</p>}
         {logs.map((log, i) => (
-          <div key={i} className="text-[10px] font-mono">
+          <div key={i} className="text-xs font-mono">
             <span className="text-muted-foreground">{log.time}</span>{" "}
             <span className="text-primary">{log.type}</span>
             <pre className="text-muted-foreground whitespace-pre-wrap ml-4">{log.data}</pre>
@@ -596,7 +596,7 @@ function WebhookLogsTab({ channel, botId }: { channel: any; botId: string }) {
     <div className="space-y-2">
       <div className="flex items-center justify-between">
         <p className="text-xs text-muted-foreground">{logs.length} 条日志（自动刷新）</p>
-        <button onClick={load} className="text-[10px] text-primary hover:underline cursor-pointer">刷新</button>
+        <button onClick={load} className="text-xs text-primary hover:underline cursor-pointer">刷新</button>
       </div>
 
       {logs.length === 0 && <p className="text-sm text-muted-foreground text-center py-8">暂无 Webhook 日志</p>}
@@ -616,12 +616,12 @@ function WebhookLogsTab({ channel, botId }: { channel: any; botId: string }) {
                 <span className="text-xs text-muted-foreground truncate flex-1">
                   {log.request_method} {log.request_url || "—"}
                 </span>
-                {log.duration_ms > 0 && <span className="text-[10px] text-muted-foreground">{log.duration_ms}ms</span>}
-                <span className="text-[10px] text-muted-foreground">{new Date(log.created_at * 1000).toLocaleTimeString()}</span>
+                {log.duration_ms > 0 && <span className="text-xs text-muted-foreground">{log.duration_ms}ms</span>}
+                <span className="text-xs text-muted-foreground">{new Date(log.created_at * 1000).toLocaleTimeString()}</span>
               </button>
 
               {isOpen && (
-                <div className="border-t px-3 py-2 space-y-2 text-[10px]">
+                <div className="border-t px-3 py-2 space-y-2 text-xs">
                   {log.plugin_id && <p className="text-muted-foreground">插件: {log.plugin_id}</p>}
 
                   {log.request_body && (

--- a/web/src/pages/plugin-debug.tsx
+++ b/web/src/pages/plugin-debug.tsx
@@ -144,20 +144,20 @@ export function PluginDebugPage() {
           <div className="flex items-center justify-between">
             <p className="text-xs font-medium">脚本</p>
             <div className="relative">
-              <Button variant="outline" size="sm" className="text-[10px] h-6" onClick={() => setShowPicker(!showPicker)}>
+              <Button variant="outline" size="sm" className="text-xs h-6" onClick={() => setShowPicker(!showPicker)}>
                 加载已有插件 <ChevronDown className="w-3 h-3 ml-1" />
               </Button>
               {showPicker && (
                 <div className="absolute right-0 top-7 z-10 w-64 border rounded-lg bg-background shadow-lg max-h-56 overflow-y-auto">
-                  {allPlugins.length === 0 && <p className="text-[10px] text-muted-foreground p-3 text-center">暂无插件</p>}
+                  {allPlugins.length === 0 && <p className="text-xs text-muted-foreground p-3 text-center">暂无插件</p>}
                   {allPlugins.map((p) => (
                     <button key={p.id} onClick={() => loadPlugin(p)}
                       className="w-full text-left px-3 py-2 text-xs hover:bg-secondary cursor-pointer border-b last:border-0 flex items-center justify-between">
                       <span>{p.icon} {p.name} <span className="text-muted-foreground">v{p.version}</span></span>
-                      <span className="text-[10px] text-muted-foreground">{p.status}</span>
+                      <span className="text-xs text-muted-foreground">{p.status}</span>
                     </button>
                   ))}
-                  <button onClick={() => setShowPicker(false)} className="w-full text-center text-[10px] text-muted-foreground py-1.5 hover:text-primary cursor-pointer">关闭</button>
+                  <button onClick={() => setShowPicker(false)} className="w-full text-center text-xs text-muted-foreground py-1.5 hover:text-primary cursor-pointer">关闭</button>
                 </div>
               )}
             </div>
@@ -176,17 +176,17 @@ export function PluginDebugPage() {
           <Card className="space-y-2 p-3">
             <p className="text-xs font-medium">请求配置</p>
             <div>
-              <label className="text-[10px] text-muted-foreground">Webhook URL</label>
+              <label className="text-xs text-muted-foreground">Webhook URL</label>
               <Input value={webhookUrl} onChange={(e) => setWebhookUrl(e.target.value)} className="h-7 text-[11px] font-mono" />
             </div>
             <p className="text-xs font-medium mt-2">模拟消息</p>
             <div className="grid grid-cols-2 gap-2">
               <div>
-                <label className="text-[10px] text-muted-foreground">发送者</label>
+                <label className="text-xs text-muted-foreground">发送者</label>
                 <Input value={sender} onChange={(e) => setSender(e.target.value)} className="h-7 text-[11px]" />
               </div>
               <div>
-                <label className="text-[10px] text-muted-foreground">消息类型</label>
+                <label className="text-xs text-muted-foreground">消息类型</label>
                 <select value={msgType} onChange={(e) => setMsgType(e.target.value)}
                   className="w-full h-7 text-[11px] rounded-md border border-input bg-transparent px-2">
                   {["text", "image", "voice", "video", "file"].map((t) => <option key={t} value={t}>{t}</option>)}
@@ -194,7 +194,7 @@ export function PluginDebugPage() {
               </div>
             </div>
             <div>
-              <label className="text-[10px] text-muted-foreground">消息内容</label>
+              <label className="text-xs text-muted-foreground">消息内容</label>
               <Input value={content} onChange={(e) => setContent(e.target.value)} className="h-7 text-[11px]" />
             </div>
             <Button size="sm" onClick={handleRun} disabled={running} className="w-full mt-1">
@@ -207,20 +207,20 @@ export function PluginDebugPage() {
             <div className="space-y-2">
               {/* Logs */}
               <Card className="p-3 space-y-0.5">
-                <p className="text-[10px] font-medium mb-1">执行日志</p>
+                <p className="text-xs font-medium mb-1">执行日志</p>
                 {(result.logs || []).map((log: string, i: number) => (
-                  <p key={i} className={`text-[10px] font-mono ${
+                  <p key={i} className={`text-xs font-mono ${
                     log.startsWith("✓") ? "text-primary" : log.startsWith("✕") ? "text-destructive" : log.startsWith("⚠") ? "text-yellow-500" : "text-muted-foreground"
                   }`}>{log}</p>
                 ))}
-                {result.error && <p className="text-[10px] font-mono text-destructive">✕ {result.error}</p>}
+                {result.error && <p className="text-xs font-mono text-destructive">✕ {result.error}</p>}
               </Card>
 
               {/* Permissions */}
               {result.permissions && (
                 <Card className="p-3">
-                  <p className="text-[10px] font-medium mb-1">解析结果</p>
-                  <div className="text-[10px] text-muted-foreground space-y-0.5">
+                  <p className="text-xs font-medium mb-1">解析结果</p>
+                  <div className="text-xs text-muted-foreground space-y-0.5">
                     <p>@grant: {(result.permissions.grants || []).join(", ") || "（未声明，默认全开）"}</p>
                     <p>@match: {result.permissions.match || "*"}</p>
                     <p>@connect: {result.permissions.connect || "*"}</p>
@@ -231,9 +231,9 @@ export function PluginDebugPage() {
               {/* Replies */}
               {(result.replies || []).length > 0 && (
                 <Card className="p-3">
-                  <p className="text-[10px] font-medium mb-1">reply() 输出 ({result.replies.length})</p>
+                  <p className="text-xs font-medium mb-1">reply() 输出 ({result.replies.length})</p>
                   {result.replies.map((r: any, i: number) => (
-                    <div key={i} className="text-[10px] font-mono">
+                    <div key={i} className="text-xs font-mono">
                       {r.type === "text" && <p className="text-primary">{r.text}</p>}
                       {r.type === "forward" && <p className="text-yellow-500">[转发二进制响应]</p>}
                       {r.type === "base64" && (
@@ -251,17 +251,17 @@ export function PluginDebugPage() {
               {result.request && (
                 <Card className="overflow-hidden">
                   <div className="px-3 py-1.5 border-b flex items-center justify-between bg-secondary/30">
-                    <p className="text-[10px] font-medium">请求</p>
-                    <span className="text-[10px] font-mono text-muted-foreground">{result.request.method} {result.request.url}</span>
+                    <p className="text-xs font-medium">请求</p>
+                    <span className="text-xs font-mono text-muted-foreground">{result.request.method} {result.request.url}</span>
                   </div>
                   {Object.keys(result.request.headers || {}).length > 0 && (
-                    <div className="px-3 py-1.5 border-b text-[10px] text-muted-foreground">
+                    <div className="px-3 py-1.5 border-b text-xs text-muted-foreground">
                       {Object.entries(result.request.headers).map(([k, v]) => (
                         <p key={k} className="font-mono">{k}: {v as string}</p>
                       ))}
                     </div>
                   )}
-                  <pre className="px-3 py-2 text-[10px] font-mono overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap">
+                  <pre className="px-3 py-2 text-xs font-mono overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap">
                     {tryPrettyJSON(result.request.body)}
                   </pre>
                 </Card>
@@ -271,12 +271,12 @@ export function PluginDebugPage() {
               {result.response && (
                 <Card className="overflow-hidden">
                   <div className="px-3 py-1.5 border-b flex items-center justify-between bg-secondary/30">
-                    <p className="text-[10px] font-medium">响应</p>
-                    <span className={`text-[10px] font-mono ${result.response.status < 400 ? "text-primary" : "text-destructive"}`}>
+                    <p className="text-xs font-medium">响应</p>
+                    <span className={`text-xs font-mono ${result.response.status < 400 ? "text-primary" : "text-destructive"}`}>
                       {result.response.status}
                     </span>
                   </div>
-                  <pre className="px-3 py-2 text-[10px] font-mono overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap">
+                  <pre className="px-3 py-2 text-xs font-mono overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap">
                     {tryPrettyJSON(result.response.body)}
                   </pre>
                 </Card>
@@ -284,7 +284,7 @@ export function PluginDebugPage() {
 
               {result.skipped && (
                 <Card className="p-3 border-yellow-500/30 bg-yellow-500/5">
-                  <p className="text-[10px] text-yellow-500">⚠ skip() 被调用 — 部署后不会发送 HTTP 请求</p>
+                  <p className="text-xs text-yellow-500">⚠ skip() 被调用 — 部署后不会发送 HTTP 请求</p>
                 </Card>
               )}
             </div>

--- a/web/src/pages/plugin-review.tsx
+++ b/web/src/pages/plugin-review.tsx
@@ -68,10 +68,10 @@ export function ReviewCard({ plugin, onRefresh }: { plugin: any; onRefresh: () =
           <div className="flex items-center gap-2 flex-wrap">
             {icon && <span className="text-lg">{icon}</span>}
             <span className="font-semibold text-sm">{name}</span>
-            <span className="text-[10px] text-muted-foreground">v{plugin.version}</span>
+            <span className="text-xs text-muted-foreground">v{plugin.version}</span>
           </div>
           <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
-          <div className="flex items-center gap-3 mt-1 text-[10px] text-muted-foreground flex-wrap">
+          <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground flex-wrap">
             <span>作者: {author || "anonymous"}</span>
             {plugin.submitter_name && <span>拥有者: {plugin.submitter_name}</span>}
             {plugin.github_url && (
@@ -119,9 +119,9 @@ export function ReviewCard({ plugin, onRefresh }: { plugin: any; onRefresh: () =
       <div className="rounded-lg border bg-card">
         <div className="px-3 py-2 border-b flex items-center justify-between">
           <p className="text-xs font-medium">源码</p>
-          <span className="text-[10px] text-muted-foreground">{scriptText.split("\n").length} 行</span>
+          <span className="text-xs text-muted-foreground">{scriptText.split("\n").length} 行</span>
         </div>
-        <pre className="p-3 text-[10px] font-mono overflow-x-auto max-h-80 overflow-y-auto whitespace-pre-wrap">
+        <pre className="p-3 text-xs font-mono overflow-x-auto max-h-80 overflow-y-auto whitespace-pre-wrap">
           {scriptText || "无脚本"}
         </pre>
       </div>

--- a/web/src/pages/plugin-submit.tsx
+++ b/web/src/pages/plugin-submit.tsx
@@ -73,7 +73,7 @@ function onRequest(ctx) {
               <Input value={url} onChange={(e) => setUrl(e.target.value)}
                 placeholder="https://github.com/user/repo/blob/main/plugin.js"
                 className="h-8 text-xs font-mono" />
-              <p className="text-[10px] text-muted-foreground">自动拉取脚本并固定 commit hash，确保审核的代码就是运行的代码。</p>
+              <p className="text-xs text-muted-foreground">自动拉取脚本并固定 commit hash，确保审核的代码就是运行的代码。</p>
             </>
           ) : (
             <>
@@ -81,7 +81,7 @@ function onRequest(ctx) {
                 placeholder={templateScript}
                 rows={16}
                 className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-[11px] font-mono placeholder:text-muted-foreground/40 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring resize-none" />
-              <p className="text-[10px] text-muted-foreground">
+              <p className="text-xs text-muted-foreground">
                 使用 <code className="bg-secondary px-1 rounded">{"// ==WebhookPlugin=="}</code> 格式声明元数据。
                 <a href="/api/webhook-plugins/skill.md" target="_blank" className="text-primary hover:underline ml-1">查看完整规范</a>
               </p>
@@ -99,7 +99,7 @@ function onRequest(ctx) {
       {/* Quick reference */}
       <Card className="space-y-2">
         <h3 className="text-xs font-medium">快速参考</h3>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-[10px]">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs">
           <div className="p-2 rounded border bg-background">
             <p className="font-medium mb-1">ctx.msg（消息）</p>
             <p className="text-muted-foreground">.sender .content .msg_type .channel_id .bot_id .timestamp .items[]</p>
@@ -113,7 +113,7 @@ function onRequest(ctx) {
             <p className="text-muted-foreground">reply(text) skip() JSON.parse/stringify</p>
           </div>
         </div>
-        <div className="flex items-center gap-3 text-[10px] text-muted-foreground">
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
           <span><Shield className="w-3 h-3 inline" /> 5s 超时</span>
           <span>栈深 64</span>
           <span>禁止 eval/require</span>

--- a/web/src/pages/plugins.tsx
+++ b/web/src/pages/plugins.tsx
@@ -236,12 +236,12 @@ function PluginCard({ plugin, onRefresh, isAdmin, isLoggedIn, mode }: {
           <div className="flex items-center gap-2 flex-wrap">
             {plugin.icon && <span className="text-base">{plugin.icon}</span>}
             <span className="text-base font-medium">{plugin.name}</span>
-            <Badge variant={s.variant} className="text-[10px]">{s.label}</Badge>
-            <span className="text-[10px] text-muted-foreground">v{plugin.version}</span>
-            {plugin.license && <span className="text-[10px] text-muted-foreground">{plugin.license}</span>}
+            <Badge variant={s.variant} className="text-xs">{s.label}</Badge>
+            <span className="text-xs text-muted-foreground">v{plugin.version}</span>
+            {plugin.license && <span className="text-xs text-muted-foreground">{plugin.license}</span>}
           </div>
           <p className="mt-1.5 text-sm leading-7 text-muted-foreground">{plugin.description}</p>
-          <div className="flex items-center gap-3 mt-1 text-[10px] text-muted-foreground flex-wrap">
+          <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground flex-wrap">
             <span>作者: {plugin.author || "anonymous"}</span>
             {(plugin.owner_name || plugin.submitter_name) && <span>拥有者: {plugin.owner_name || plugin.submitter_name}</span>}
             <span>{plugin.install_count} 次安装</span>
@@ -254,13 +254,13 @@ function PluginCard({ plugin, onRefresh, isAdmin, isLoggedIn, mode }: {
             {plugin.commit_hash && <span className="font-mono">{plugin.commit_hash.slice(0, 7)}</span>}
           </div>
           {/* Security summary */}
-          <div className="flex items-center gap-2 mt-1 text-[10px] flex-wrap">
+          <div className="flex items-center gap-2 mt-1 text-xs flex-wrap">
             <span className={riskColors[riskLevel]}><Shield className="w-3 h-3 inline mr-0.5" />{riskLabels[riskLevel]}</span>
             <span className="text-muted-foreground">权限: {grants.length > 0 ? grants.join(", ") : "none"}</span>
             <span className="text-muted-foreground">消息: {matchTypes}</span>
             {connectDomains !== "*" && <span className="text-muted-foreground">域名: {connectDomains}</span>}
           </div>
-          {plugin.reject_reason && <p className="text-[10px] text-destructive mt-0.5">拒绝原因：{plugin.reject_reason}</p>}
+          {plugin.reject_reason && <p className="text-xs text-destructive mt-0.5">拒绝原因：{plugin.reject_reason}</p>}
         </div>
         <div className="flex items-center gap-1 shrink-0">
           <Button size="sm" variant="ghost" className="h-7 text-xs" onClick={toggleVersions}>
@@ -300,11 +300,11 @@ function PluginCard({ plugin, onRefresh, isAdmin, isLoggedIn, mode }: {
 
       {showVersions && versions && (
         <div className="space-y-1">
-          <p className="text-[10px] font-medium">发版历史</p>
+          <p className="text-xs font-medium">发版历史</p>
           {versions.map((v) => (
-            <div key={v.id} className="flex items-center gap-2 text-[10px] p-1.5 rounded border bg-background">
+            <div key={v.id} className="flex items-center gap-2 text-xs p-1.5 rounded border bg-background">
               <span className="font-mono font-medium">v{v.version}</span>
-              <Badge variant={v.status === "approved" ? "default" : v.status === "rejected" || v.status === "cancelled" ? "destructive" : "outline"} className="text-[10px]">
+              <Badge variant={v.status === "approved" ? "default" : v.status === "rejected" || v.status === "cancelled" ? "destructive" : "outline"} className="text-xs">
                 {v.status === "approved" ? "✓" : v.status === "rejected" ? "✕" : v.status === "superseded" ? "⊘" : v.status === "cancelled" ? "✕" : "⏳"}
               </Badge>
               <span className="text-muted-foreground">{v.status}</span>
@@ -317,20 +317,20 @@ function PluginCard({ plugin, onRefresh, isAdmin, isLoggedIn, mode }: {
               )}
             </div>
           ))}
-          {versions.length === 0 && <p className="text-[10px] text-muted-foreground">暂无历史版本</p>}
+          {versions.length === 0 && <p className="text-xs text-muted-foreground">暂无历史版本</p>}
         </div>
       )}
 
       {showScript && (
         <div>
           {detail?.script ? (
-            <pre className="text-[10px] bg-background border rounded p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap font-mono">{detail.script}</pre>
+            <pre className="text-xs bg-background border rounded p-3 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap font-mono">{detail.script}</pre>
           ) : plugin.github_url ? (
             <a href={plugin.github_url} target="_blank" rel="noopener" className="text-xs text-primary flex items-center gap-1">
               <ExternalLink className="w-3 h-3" /> 在 GitHub 查看源码
             </a>
           ) : (
-            <p className="text-[10px] text-muted-foreground">登录后可查看脚本源码</p>
+            <p className="text-xs text-muted-foreground">登录后可查看脚本源码</p>
           )}
         </div>
       )}
@@ -367,13 +367,13 @@ function MyPluginsTab({ plugins, onRefresh }: { plugins: any[]; onRefresh: () =>
               <div className="min-w-0">
                 <div className="flex items-center gap-1.5">
                   <span className="text-xs font-medium">{p.name}</span>
-                  <span className="text-[10px] text-muted-foreground">v{p.version}</span>
-                  <Badge variant={s.variant} className="text-[10px]">{s.label}</Badge>
+                  <span className="text-xs text-muted-foreground">v{p.version}</span>
+                  <Badge variant={s.variant} className="text-xs">{s.label}</Badge>
                 </div>
-                <p className="text-[10px] text-muted-foreground truncate">{p.description}</p>
+                <p className="text-xs text-muted-foreground truncate">{p.description}</p>
               </div>
             </div>
-            <div className="text-[10px] text-muted-foreground shrink-0 ml-2 text-right">
+            <div className="text-xs text-muted-foreground shrink-0 ml-2 text-right">
               <p>{p.install_count} 安装</p>
               <p>{new Date(p.created_at * 1000).toLocaleDateString()}</p>
             </div>

--- a/web/src/pages/settings.tsx
+++ b/web/src/pages/settings.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
-import { Card } from "../components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { api } from "../lib/api";
 import { Link2, Unlink, Trash2, KeyRound, Plus, Sun, Moon, Monitor } from "lucide-react";
 import { useTheme, type Theme } from "../lib/theme";
@@ -63,33 +63,41 @@ export function SettingsPage() {
         </div>
       )}
 
-      {/* Account info */}
-      <Card className="space-y-3">
-        <h3 className="text-sm font-medium">外观</h3>
-        <div className="flex gap-2" role="group" aria-label="主题选择">
-          {themeOptions.map(({ value, label, icon }) => (
-            <Button
-              key={value}
-              variant={theme === value ? "default" : "outline"}
-              size="sm"
-              onClick={() => setTheme(value)}
-              aria-pressed={theme === value}
-              aria-label={label}
-            >
-              {icon}
-              {label}
-            </Button>
-          ))}
-        </div>
+      {/* 外观 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>外观</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-2" role="group" aria-label="主题选择">
+            {themeOptions.map(({ value, label, icon }) => (
+              <Button
+                key={value}
+                variant={theme === value ? "default" : "outline"}
+                size="sm"
+                onClick={() => setTheme(value)}
+                aria-pressed={theme === value}
+                aria-label={label}
+              >
+                {icon}
+                {label}
+              </Button>
+            ))}
+          </div>
+        </CardContent>
       </Card>
 
-      <Card className="space-y-3">
-        <h3 className="text-sm font-medium">账号信息</h3>
-        <div className="text-sm space-y-1">
-          <p><span className="text-muted-foreground">用户名：</span>{user.username}</p>
-          <p><span className="text-muted-foreground">显示名：</span>{user.display_name}</p>
-          <p><span className="text-muted-foreground">角色：</span>{user.role === "superadmin" ? "超级管理员" : user.role === "admin" ? "管理员" : "成员"}</p>
-        </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>账号信息</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-1 text-sm">
+            <p><span className="text-muted-foreground">用户名：</span>{user.username}</p>
+            <p><span className="text-muted-foreground">显示名：</span>{user.display_name}</p>
+            <p><span className="text-muted-foreground">角色：</span>{user.role === "superadmin" ? "超级管理员" : user.role === "admin" ? "管理员" : "成员"}</p>
+          </div>
+        </CardContent>
       </Card>
 
       <ChangePasswordSection />
@@ -97,37 +105,41 @@ export function SettingsPage() {
 
       {/* OAuth binding */}
       {oauthProviders.length > 0 && (
-        <Card className="space-y-3">
-          <h3 className="text-sm font-medium">第三方账号绑定</h3>
-          <div className="space-y-2">
-            {oauthProviders.map((provider) => {
-              const account = oauthAccounts.find((a) => a.provider === provider);
-              const linked = !!account;
-              return (
-                <div key={provider} className="flex items-center justify-between p-3 rounded-lg border bg-background">
-                  <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded-full bg-secondary flex items-center justify-center">
-                      <span className="text-xs font-medium">{(providerLabels[provider] || provider).charAt(0).toUpperCase()}</span>
+        <Card>
+          <CardHeader>
+            <CardTitle>第三方账号绑定</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-col gap-2">
+              {oauthProviders.map((provider) => {
+                const account = oauthAccounts.find((a) => a.provider === provider);
+                const linked = !!account;
+                return (
+                  <div key={provider} className="flex items-center justify-between p-3 rounded-lg border bg-background">
+                    <div className="flex items-center gap-3">
+                      <div className="size-8 rounded-full bg-secondary flex items-center justify-center shrink-0">
+                        <span className="text-xs font-medium">{(providerLabels[provider] || provider).charAt(0).toUpperCase()}</span>
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium">{providerLabels[provider] || provider}</p>
+                        <p className="text-xs text-muted-foreground">{linked ? `已绑定：${account.username}` : "未绑定"}</p>
+                      </div>
                     </div>
-                    <div>
-                      <p className="text-sm font-medium">{providerLabels[provider] || provider}</p>
-                      <p className="text-xs text-muted-foreground">{linked ? `已绑定：${account.username}` : "未绑定"}</p>
-                    </div>
+                    {linked ? (
+                      <Button variant="ghost" size="sm" onClick={async () => {
+                        if (!confirm(`解绑 ${providerLabels[provider]}？`)) return;
+                        try { await api.unlinkOAuth(provider); load(); } catch (e: any) { alert(e.message); }
+                      }}><Unlink className="w-3.5 h-3.5 mr-1" /> 解绑</Button>
+                    ) : (
+                      <Button variant="outline" size="sm" onClick={() => { window.location.href = `/api/me/linked-accounts/${provider}/bind`; }}>
+                        <Link2 className="w-3.5 h-3.5 mr-1" /> 绑定
+                      </Button>
+                    )}
                   </div>
-                  {linked ? (
-                    <Button variant="ghost" size="sm" onClick={async () => {
-                      if (!confirm(`解绑 ${providerLabels[provider]}？`)) return;
-                      try { await api.unlinkOAuth(provider); load(); } catch (e: any) { alert(e.message); }
-                    }}><Unlink className="w-3.5 h-3.5 mr-1" /> 解绑</Button>
-                  ) : (
-                    <Button variant="outline" size="sm" onClick={() => { window.location.href = `/api/me/linked-accounts/${provider}/bind`; }}>
-                      <Link2 className="w-3.5 h-3.5 mr-1" /> 绑定
-                    </Button>
-                  )}
-                </div>
-              );
-            })}
-          </div>
+                );
+              })}
+            </div>
+          </CardContent>
         </Card>
       )}
     </div>
@@ -157,20 +169,24 @@ function ChangePasswordSection() {
   }
 
   return (
-    <Card className="space-y-3">
-      <h3 className="text-sm font-medium">修改密码</h3>
-      <form onSubmit={handleSubmit} className="space-y-2">
-        <Input type="password" placeholder="当前密码" value={oldPwd} onChange={(e) => setOldPwd(e.target.value)} className="h-8 text-xs" />
-        <Input type="password" placeholder="新密码（至少 8 位）" value={newPwd} onChange={(e) => setNewPwd(e.target.value)} className="h-8 text-xs" />
-        <Input type="password" placeholder="确认新密码" value={confirmPwd} onChange={(e) => setConfirmPwd(e.target.value)} className="h-8 text-xs" />
-        <div className="flex items-center justify-between">
-          <div>
-            {error && <span className="text-[10px] text-destructive">{error}</span>}
-            {success && <span className="text-[10px] text-primary">{success}</span>}
+    <Card>
+      <CardHeader>
+        <CardTitle>修改密码</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+          <Input type="password" placeholder="当前密码" value={oldPwd} onChange={(e) => setOldPwd(e.target.value)} />
+          <Input type="password" placeholder="新密码（至少 8 位）" value={newPwd} onChange={(e) => setNewPwd(e.target.value)} />
+          <Input type="password" placeholder="确认新密码" value={confirmPwd} onChange={(e) => setConfirmPwd(e.target.value)} />
+          <div className="flex items-center justify-between">
+            <div>
+              {error && <span className="text-xs text-destructive">{error}</span>}
+              {success && <span className="text-xs text-primary">{success}</span>}
+            </div>
+            <Button type="submit" size="sm" disabled={saving}>{saving ? "..." : "修改密码"}</Button>
           </div>
-          <Button type="submit" size="sm" disabled={saving}>{saving ? "..." : "修改密码"}</Button>
-        </div>
-      </form>
+        </form>
+      </CardContent>
     </Card>
   );
 }
@@ -209,36 +225,42 @@ function PasskeySection() {
   }
 
   return (
-    <Card className="space-y-3">
-      <div className="flex items-center justify-between">
-        <h3 className="text-sm font-medium">Passkey</h3>
-        <Button variant="outline" size="sm" className="text-xs h-7" onClick={handleAdd} disabled={adding}>
-          <Plus className="w-3 h-3 mr-1" /> {adding ? "注册中..." : "添加 Passkey"}
-        </Button>
-      </div>
-      <p className="text-xs text-muted-foreground">使用指纹、Face ID 或安全密钥登录，无需密码。</p>
-      {error && <p className="text-[10px] text-destructive">{error}</p>}
-      {passkeys.length === 0 ? (
-        <p className="text-[10px] text-muted-foreground">暂未绑定任何 Passkey</p>
-      ) : (
-        <div className="space-y-1">
-          {passkeys.map((pk) => (
-            <div key={pk.id} className="flex items-center justify-between p-2 rounded-lg border bg-background">
-              <div className="flex items-center gap-2">
-                <KeyRound className="w-4 h-4 text-muted-foreground" />
-                <div>
-                  <p className="text-xs font-mono">{pk.id.slice(0, 16)}...</p>
-                  <p className="text-[10px] text-muted-foreground">{new Date(pk.created_at * 1000).toLocaleDateString()}</p>
-                </div>
-              </div>
-              <Button variant="ghost" size="sm" className="h-6" onClick={async () => {
-                if (!confirm("删除此 Passkey？")) return;
-                try { await api.deletePasskey(pk.id); load(); } catch {}
-              }}><Trash2 className="w-3 h-3 text-destructive" /></Button>
-            </div>
-          ))}
+    <Card>
+      <CardHeader>
+        <CardTitle>Passkey</CardTitle>
+        <div className="col-start-2 row-span-2 row-start-1 self-start justify-self-end">
+          <Button variant="outline" size="sm" onClick={handleAdd} disabled={adding}>
+            <Plus /> {adding ? "注册中..." : "添加 Passkey"}
+          </Button>
         </div>
-      )}
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-muted-foreground">使用指纹、Face ID 或安全密钥登录，无需密码。</p>
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          {passkeys.length === 0 ? (
+            <p className="text-xs text-muted-foreground">暂未绑定任何 Passkey</p>
+          ) : (
+            <div className="flex flex-col gap-1">
+              {passkeys.map((pk) => (
+                <div key={pk.id} className="flex items-center justify-between p-2 rounded-lg border bg-background">
+                  <div className="flex items-center gap-2">
+                    <KeyRound className="size-4 text-muted-foreground" />
+                    <div>
+                      <p className="text-xs font-mono">{pk.id.slice(0, 16)}...</p>
+                      <p className="text-xs text-muted-foreground">{new Date(pk.created_at * 1000).toLocaleDateString()}</p>
+                    </div>
+                  </div>
+                  <Button variant="ghost" size="sm" onClick={async () => {
+                    if (!confirm("删除此 Passkey？")) return;
+                    try { await api.deletePasskey(pk.id); load(); } catch {}
+                  }}><Trash2 className="size-4 text-destructive" /></Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </CardContent>
     </Card>
   );
 }


### PR DESCRIPTION
## 变更内容

### 侧边栏重构
- 安装 shadcn `sidebar` / `dropdown-menu` / `avatar` / `tooltip` / `sheet` 组件
- 用 `SidebarProvider` + `Sidebar` + `SidebarInset` 替换原来手写的 `<aside>`
- 支持 `collapsible="icon"` 折叠模式，折叠时悬浮显示 tooltip
- 导航按分组用 `SidebarSeparator` 分隔，底部用户菜单改为 `DropdownMenu`
- 修复 Logo 在折叠模式下的 size 问题
- 分组标签（Webhook 插件、系统管理）去掉图标，改为纯文字
- 修复 `SidebarMenu` 默认 `gap-0` 改为 `gap-0.5`，item 之间有间距
- 账号设置图标改为 `User`，与系统配置的 `Settings` 图标区分

### Card 组件修复
- `settings.tsx` / `admin.tsx` 所有 `Card` 改为正确的 `CardHeader` + `CardTitle` + `CardContent` 组合，修复缺少水平 padding 的问题

### 代码规范清理
- 批量替换全站 151 处 `text-[10px]` 为 `text-xs`（shadcn 最小字号规范为 12px）
- 修复 `space-y-*` → `flex flex-col gap-*`、`w-8 h-8` → `size-8` 等 shadcn skill 违规项

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned sidebar navigation with improved user account dropdown menu and admin controls
  * Added avatar components with badges and group support
  * Introduced dropdown menus with submenus and checkbox/radio options
  * Added side sheet panels for dialogs and modals
  * Added tooltip system across the UI
  * Added mobile viewport detection

* **Improvements**
  * Refactored Settings, Admin, and App management pages with structured card-based layouts
  * Improved text sizing consistency across pages for better readability
  * Enhanced admin dashboard with better-organized sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->