### PR TITLE
fix(web): sidebar logo links to homepage, fix public page auth redirect

### DIFF
--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -71,7 +71,7 @@ export function Layout() {
           <SidebarMenu>
             <SidebarMenuItem>
               <SidebarMenuButton asChild tooltip="OpenILink Hub">
-                <Link to="/dashboard">
+                <Link to="/">
                   <LayoutDashboard />
                   <span className="font-semibold tracking-tight">OpenILink Hub</span>
                 </Link>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,7 +5,11 @@ async function request<T>(url: string, options?: RequestInit): Promise<T> {
     ...options,
   });
   if (res.status === 401) {
-    window.location.href = "/login";
+    const path = window.location.pathname;
+    const isPublic = path === "/" || path.startsWith("/webhook-plugins");
+    if (!isPublic) {
+      window.location.href = "/login";
+    }
     throw new Error("unauthorized");
   }
   const data = await res.json();

--- a/web/src/pages/home.tsx
+++ b/web/src/pages/home.tsx
@@ -5,6 +5,7 @@ import { Card } from "../components/ui/card";
 import { HexagonBackground } from "../components/ui/hexagon-background";
 import { cn } from "../lib/utils";
 import { Bot, Puzzle, Webhook, Cable, Shield, Zap } from "lucide-react";
+import { api } from "../lib/api";
 
 const features = [
   { icon: Bot, title: "多 Bot 管理", desc: "同时管理多个微信 Bot，每个 Bot 独立运行、独立配置" },
@@ -17,6 +18,11 @@ const features = [
 
 export function HomePage() {
   const [isScrolled, setIsScrolled] = useState(false);
+  const [loggedIn, setLoggedIn] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    api.me().then(() => setLoggedIn(true)).catch(() => setLoggedIn(false));
+  }, []);
 
   useEffect(() => {
     const updateScrollState = () => {
@@ -55,9 +61,15 @@ export function HomePage() {
             <Link to="/webhook-plugins">
               <Button variant="ghost" size="sm" className="px-3 text-sm">插件市场</Button>
             </Link>
-            <Link to="/login">
-              <Button size="sm" className="px-3 text-sm">登录</Button>
-            </Link>
+            {loggedIn ? (
+              <Link to="/dashboard">
+                <Button size="sm" className="px-3 text-sm">进入控制台</Button>
+              </Link>
+            ) : (
+              <Link to="/login">
+                <Button size="sm" className="px-3 text-sm">登录</Button>
+              </Link>
+            )}
           </div>
         </div>
         <div
@@ -76,7 +88,7 @@ export function HomePage() {
             开源的微信 Bot 管理与消息中继平台。连接你的微信，通过 WebSocket、HTTP API 或 Webhook 接收和发送消息。
           </p>
           <div className="mt-8 flex justify-center gap-4 sm:mt-10">
-            <Link to="/login">
+            <Link to={loggedIn ? "/dashboard" : "/login"}>
               <Button size="lg" className="px-5 text-sm">开始使用</Button>
             </Link>
             <a href="https://github.com/openilink/openilink-hub" target="_blank" rel="noopener">


### PR DESCRIPTION
## Changes

- **Sidebar logo**: clicking the OpenILink Hub logo now navigates to `/` (homepage) instead of `/dashboard`
- **Homepage auth state**: homepage detects login state and shows "进入控制台" when logged in
- **Public page redirect fix**: `api.ts` 401 handler no longer auto-redirects on public paths (`/` and `/webhook-plugins`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home page now intelligently displays authentication-aware navigation, showing "Dashboard" link for logged-in users and "Login" link for guests.

* **Bug Fixes**
  * Improved authentication error handling to preserve access to public pages without unnecessary redirects.

* **Chores**
  * Updated logo navigation to return to homepage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->