### PR TITLE
fix: stabilize local startup and remove invalid admin route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
 openilink-hub
+AGENTS.md
 internal/web/dist/*
 !internal/web/dist/.gitkeep
 *.db
 *.db-wal
 *.db-shm
+.env
+.env.*
+*.log
 .idea/
 .vscode/
 *.swp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,11 @@ services:
       POSTGRES_USER: openilink
       POSTGRES_PASSWORD: openilink
       POSTGRES_DB: openilink
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U openilink -d openilink"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
     ports:
       - "15432:5432"
     volumes:
@@ -24,6 +29,7 @@ services:
 
   hub:
     build: .
+    restart: on-failure
     ports:
       - "9800:9800"
     environment:
@@ -40,8 +46,10 @@ services:
       # LINUXDO_CLIENT_ID:
       # LINUXDO_CLIENT_SECRET:
     depends_on:
-      - postgres
-      - minio
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_started
 
 volumes:
   pgdata:

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -46,7 +46,6 @@ createRoot(document.getElementById("root")!).render(
           <Route path="admin" element={<AdminPage tab="dashboard" />} />
           <Route path="admin/users" element={<AdminPage tab="users" />} />
           <Route path="admin/config" element={<AdminPage tab="config" />} />
-          <Route path="admin/apps" element={<AdminPage tab="apps" />} />
         </Route>
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
## Summary
- add a PostgreSQL healthcheck and wait for it before starting the hub in docker compose
- restart the hub on failure to smooth over transient startup races in local development
- remove the stray `admin/apps` route that passes an unsupported tab value to `AdminPage`
- ignore local-only files such as `AGENTS.md`, env files, and log files

## Testing
- not run (per request)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Enhanced database service reliability with automated health checks and restart policies.

* **Breaking Changes**
  * Removed routing configuration for the admin apps page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->