### PR TITLE
refactor: remove sidebar collapsible

### DIFF
--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -196,7 +196,7 @@ export function Layout() {
                       </SidebarMenuSubButton>
                     </SidebarMenuSubItem>
                     <SidebarMenuSubItem>
-                      <SidebarMenuSubButton asChild size="sm" isActive={location.pathname === "/dashboard/apps/my" || location.pathname === "/dashboard/apps"}>
+                      <SidebarMenuSubButton asChild size="sm" isActive={isActive("/dashboard/apps/my") || location.pathname === "/dashboard/apps"}>
                         <Link to="/dashboard/apps/my">我的应用</Link>
                       </SidebarMenuSubButton>
                     </SidebarMenuSubItem>


### PR DESCRIPTION
## Summary
- 移除侧边栏三个菜单组（账号管理、扩展、管理）的折叠功能
- 子菜单项始终展开显示，提升导航可发现性
- 清理 Collapsible、CollapsibleTrigger、CollapsibleContent 及 ChevronRight 相关导入

## Test plan
- [ ] 验证侧边栏三个分组的子菜单始终可见
- [ ] 验证侧边栏收缩为图标模式时 tooltip 仍正常
- [ ] 验证各子菜单链接跳转及 active 状态高亮正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Sidebar menu sections (Account Management, Extensions, Admin) are now permanently visible and no longer collapsible. Expand/collapse functionality has been removed from these navigation sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->