### PR TITLE
fix: session expired 时直接弹出二维码引导重新绑定

### DIFF
--- a/web/src/pages/bots.tsx
+++ b/web/src/pages/bots.tsx
@@ -164,7 +164,7 @@ export function BotsPage() {
       ) : (
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {bots.map((bot) => (
-            <BotInstanceCard key={bot.id} bot={bot} onRefresh={load} onRebind={() => { setBinding(true); startBind(); }} />
+            <BotInstanceCard key={bot.id} bot={bot} onRefresh={load} onRebind={() => setBinding(true)} />
           ))}
           
           {bots.length === 0 && (


### PR DESCRIPTION
## Summary
- Bot 会话过期时，卡片提示区新增「重新扫码」按钮，点击即弹出二维码弹窗引导用户重新绑定
- 之前只有文字提示，用户需要手动点「添加账号」才能重新绑定，体验不佳

## Test plan
- [ ] 将某个 bot 状态设为 `session_expired`，确认卡片上出现「重新扫码」按钮
- [ ] 点击按钮，确认二维码弹窗正常弹出并可完成绑定流程

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a convenient "re-scan" (“重新扫码”) button on the session-expired screen so users can quickly rebind their bot instance without leaving the page.
  * Improved session recovery flow by presenting the re-binding action directly in the UI, simplifying and speeding up reconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->