### PR TITLE
Enable WebSocket proxy for Vite dev server

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       "/api": {
         target: "http://localhost:9800",
         changeOrigin: true,
+        ws: true,
       },
     },
   },


### PR DESCRIPTION
## Problem / Intent

本地开发时，微信扫码后 WebSocket 连接无响应。Vite dev server 的 `/api` 代理未配置 `ws: true`，导致 WebSocket 升级请求被拦截，无法转发到后端。

## Approach

在 `vite.config.ts` 的代理配置中添加 `ws: true`，使 Vite 同时代理 HTTP 和 WebSocket 请求到本地后端。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced development server configuration to support real-time communication protocols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->