### PR TITLE
feat(web): add Marketplace UI with unified install flow

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -126,8 +126,8 @@ export const api = {
   // Apps
   createApp: (data: any) =>
     request<any>("/api/apps", { method: "POST", body: JSON.stringify(data) }),
-  listApps: (opts?: { listed?: boolean }) =>
-    request<any[]>(`/api/apps${opts?.listed ? "?listed=true" : ""}`),
+  listApps: (opts?: { listing?: boolean }) =>
+    request<any[]>(`/api/apps${opts?.listing ? "?listing=true" : ""}`),
   getApp: (id: string) => request<any>(`/api/apps/${id}`),
   updateApp: (id: string, data: any) =>
     request<any>(`/api/apps/${id}`, { method: "PUT", body: JSON.stringify(data) }),
@@ -137,8 +137,8 @@ export const api = {
 
   // Admin: Apps
   adminListApps: () => request<any[]>("/api/admin/apps"),
-  setAppListed: (id: string, listed: boolean) =>
-    request(`/api/admin/apps/${id}/listed`, { method: "PUT", body: JSON.stringify({ listed }) }),
+  setAppListing: (id: string, listing: string) =>
+    request(`/api/admin/apps/${id}/listing`, { method: "PUT", body: JSON.stringify({ listing }) }),
 
   // App Installations
   installApp: (appId: string, data: any) =>
@@ -174,6 +174,20 @@ export const api = {
     request<any[]>(
       `/api/bots/${botId}/webhook-logs?limit=${limit}${channelId ? "&channel_id=" + channelId : ""}`,
     ),
+
+  // Marketplace
+  getMarketplace: () => request<any[]>("/api/marketplace"),
+  syncMarketplaceApp: (slug: string) => request<any>(`/api/marketplace/sync/${slug}`, { method: "POST" }),
+
+  // Registry admin
+  getRegistries: () => request<any[]>("/api/admin/registries"),
+  createRegistry: (data: { name: string; url: string }) => request<any>("/api/admin/registries", { method: "POST", body: JSON.stringify(data) }),
+  updateRegistry: (id: string, data: { enabled: boolean }) => request<any>(`/api/admin/registries/${id}`, { method: "PUT", body: JSON.stringify(data) }),
+  deleteRegistry: (id: string) => request<any>(`/api/admin/registries/${id}`, { method: "DELETE" }),
+
+  // Registry config
+  getRegistryConfig: () => request<any>("/api/admin/config/registry"),
+  setRegistryConfig: (data: { enabled: string }) => request<any>("/api/admin/config/registry", { method: "PUT", body: JSON.stringify(data) }),
 
   // Admin: Dashboard
   adminStats: () => request<any>("/api/admin/stats"),

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -1,15 +1,15 @@
 export const SCOPE_DESCRIPTIONS: Record<string, string> = {
-  "messages.send": "在已授权的对话中发送消息",
-  "messages.read": "查看消息和对话内容",
-  "contacts.read": "查看联系人基本信息",
-  "bot.read": "查看账号基本信息和状态",
+  "message:write": "通过 Bot 发送微信消息",
+  "message:read": "接收 Bot 的微信消息事件",
+  "contact:read": "读取 Bot 的联系人列表",
+  "bot:read": "读取 Bot 的状态和基本信息",
 };
 
 export const SCOPES = [
-  { key: "messages.send", label: "发送消息", description: "在已授权的对话中发送消息", category: "write" as const },
-  { key: "messages.read", label: "读取消息", description: "查看消息和对话内容", category: "read" as const },
-  { key: "contacts.read", label: "读取联系人", description: "查看联系人基本信息", category: "read" as const },
-  { key: "bot.read", label: "读取账号信息", description: "查看账号基本信息和状态", category: "read" as const },
+  { key: "message:write", label: "发送消息", description: "通过 Bot 发送微信消息", category: "write" as const },
+  { key: "message:read", label: "接收消息", description: "接收 Bot 的微信消息事件", category: "read" as const },
+  { key: "contact:read", label: "读取联系人", description: "读取 Bot 的联系人列表", category: "read" as const },
+  { key: "bot:read", label: "读取 Bot 信息", description: "读取 Bot 的状态和基本信息", category: "read" as const },
 ];
 
 export const EVENT_TYPES = [

--- a/web/src/pages/admin-apps.tsx
+++ b/web/src/pages/admin-apps.tsx
@@ -21,9 +21,10 @@ export function AdminAppsTab() {
     setEditing(false);
   }
 
-  async function toggleListed(e: React.MouseEvent, app: any) {
+  async function toggleListing(e: React.MouseEvent, app: any) {
     e.stopPropagation();
-    try { await api.setAppListed(app.id, !app.listed); load(); } catch (err: any) { setError(err.message); }
+    const newListing = app.listing === "listed" ? "unlisted" : "listed";
+    try { await api.setAppListing(app.id, newListing); load(); } catch (err: any) { setError(err.message); }
   }
 
   async function handleDelete(app: any) {
@@ -56,9 +57,9 @@ export function AdminAppsTab() {
                 <div className="flex items-center gap-1.5">
                   <span className="text-xs font-medium">{app.name}</span>
                   <span className="text-xs text-muted-foreground font-mono">{app.slug}</span>
-                  {app.listed && <Badge variant="default" className="text-[10px]">已上架</Badge>}
-                  {app.listing_status === "pending" && <Badge variant="outline" className="text-[10px] text-orange-500 border-orange-500">待审核</Badge>}
-                  {app.listing_status === "rejected" && <Badge variant="destructive" className="text-[10px]">已拒绝</Badge>}
+                  {app.listing === "listed" && <Badge variant="default" className="text-[10px]">已上架</Badge>}
+                  {app.listing === "pending" && <Badge variant="outline" className="text-[10px] text-orange-500 border-orange-500">待审核</Badge>}
+                  {app.listing === "rejected" && <Badge variant="destructive" className="text-[10px]">已拒绝</Badge>}
                 </div>
                 <p className="text-xs text-muted-foreground">
                   {app.owner_name && `by ${app.owner_name} · `}
@@ -67,7 +68,7 @@ export function AdminAppsTab() {
               </div>
             </div>
             <div className="flex items-center gap-1 shrink-0">
-              {app.listing_status === "pending" && (
+              {app.listing === "pending" && (
                 <>
                   <button onClick={(e) => { e.stopPropagation(); handleApprove(app); }}
                     className="text-xs px-2 py-0.5 rounded cursor-pointer bg-primary/10 text-primary">通过</button>
@@ -75,9 +76,9 @@ export function AdminAppsTab() {
                     className="text-xs px-2 py-0.5 rounded cursor-pointer bg-destructive/10 text-destructive">拒绝</button>
                 </>
               )}
-              <button onClick={(e) => toggleListed(e, app)}
-                className={`text-xs px-2 py-0.5 rounded cursor-pointer ${app.listed ? "bg-primary/10 text-primary" : "bg-secondary text-muted-foreground"}`}>
-                {app.listed ? "下架" : "上架"}
+              <button onClick={(e) => toggleListing(e, app)}
+                className={`text-xs px-2 py-0.5 rounded cursor-pointer ${app.listing === "listed" ? "bg-primary/10 text-primary" : "bg-secondary text-muted-foreground"}`}>
+                {app.listing === "listed" ? "下架" : "上架"}
               </button>
             </div>
           </div>
@@ -91,7 +92,7 @@ export function AdminAppsTab() {
             {editing ? (
               <AppEditForm app={selected} onSave={() => { setEditing(false); load(); setSelected(null); }} onCancel={() => setEditing(false)} />
             ) : (
-              <AppDetailView app={selected} onEdit={() => setEditing(true)} onDelete={() => handleDelete(selected)} onClose={() => setSelected(null)} onToggleListed={() => { api.setAppListed(selected.id, !selected.listed).then(() => { load(); setSelected({ ...selected, listed: !selected.listed }); }); }} />
+              <AppDetailView app={selected} onEdit={() => setEditing(true)} onDelete={() => handleDelete(selected)} onClose={() => setSelected(null)} onToggleListing={() => { const newListing = selected.listing === "listed" ? "unlisted" : "listed"; api.setAppListing(selected.id, newListing).then(() => { load(); setSelected({ ...selected, listing: newListing }); }); }} />
             )}
           </div>
         </div>
@@ -100,7 +101,7 @@ export function AdminAppsTab() {
   );
 }
 
-function AppDetailView({ app, onEdit, onDelete, onClose, onToggleListed }: { app: any; onEdit: () => void; onDelete: () => void; onClose: () => void; onToggleListed: () => void }) {
+function AppDetailView({ app, onEdit, onDelete, onClose, onToggleListing }: { app: any; onEdit: () => void; onDelete: () => void; onClose: () => void; onToggleListing: () => void }) {
   const tools = (app.tools || []) as any[];
   const events = (app.events || []) as string[];
   const scopes = (app.scopes || []) as string[];
@@ -172,8 +173,8 @@ function AppDetailView({ app, onEdit, onDelete, onClose, onToggleListed }: { app
           <Button variant="destructive" size="sm" onClick={onDelete}>
             <Trash2 className="w-3.5 h-3.5 mr-1" /> 删除
           </Button>
-          <Button variant="outline" size="sm" onClick={onToggleListed}>
-            {app.listed ? "下架" : "上架"}
+          <Button variant="outline" size="sm" onClick={onToggleListing}>
+            {app.listing === "listed" ? "下架" : "上架"}
           </Button>
         </div>
         <div className="flex gap-2">

--- a/web/src/pages/admin-overview.tsx
+++ b/web/src/pages/admin-overview.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { BarChart3, Users, Cpu, Globe, Blocks, Database, Settings } from "lucide-react";
+import { BarChart3, Users, Cpu, Globe, Blocks, Database, Settings, Trash2, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -107,10 +107,165 @@ export function AdminOverviewPage() {
           <CardFooter className="bg-muted/30 pt-4 flex justify-end"><Button onClick={handleSaveAI} disabled={saving} className="rounded-full">保存</Button></CardFooter>
         </Card>
 
-        <Card className="border-border/50 bg-muted/10 opacity-60 rounded-[2rem] flex items-center justify-center border-dashed">
-          <div className="text-center p-8"><Settings className="h-10 w-10 mx-auto opacity-20 mb-4" /><p className="text-xs font-bold uppercase tracking-widest text-muted-foreground">更多配置开发中</p></div>
-        </Card>
+        <RegistryConfigCard />
       </div>
     </div>
+  );
+}
+
+// ==================== Registry Config ====================
+
+function RegistryConfigCard() {
+  const [registryConfig, setRegistryConfig] = useState<any>(null);
+  const [registries, setRegistries] = useState<any[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newUrl, setNewUrl] = useState("");
+  const [adding, setAdding] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    api.getRegistryConfig().then(setRegistryConfig).catch(() => setRegistryConfig({ enabled: "false" }));
+    api.getRegistries().then(r => setRegistries(r || [])).catch(() => {});
+  }, []);
+
+  async function handleToggleExpose() {
+    setSaving(true);
+    try {
+      const newEnabled = registryConfig?.enabled === "true" ? "false" : "true";
+      await api.setRegistryConfig({ enabled: newEnabled });
+      setRegistryConfig({ ...registryConfig, enabled: newEnabled });
+      toast({ title: "Registry 配置已保存" });
+    } catch (e: any) {
+      toast({ variant: "destructive", title: "保存失败", description: e.message });
+    }
+    setSaving(false);
+  }
+
+  async function handleAddRegistry() {
+    if (!newName.trim() || !newUrl.trim()) return;
+    setAdding(true);
+    try {
+      await api.createRegistry({ name: newName.trim(), url: newUrl.trim() });
+      setNewName("");
+      setNewUrl("");
+      const r = await api.getRegistries();
+      setRegistries(r || []);
+      toast({ title: "Registry 已添加" });
+    } catch (e: any) {
+      toast({ variant: "destructive", title: "添加失败", description: e.message });
+    }
+    setAdding(false);
+  }
+
+  async function handleToggleRegistry(reg: any) {
+    try {
+      await api.updateRegistry(reg.id, { enabled: !reg.enabled });
+      const r = await api.getRegistries();
+      setRegistries(r || []);
+    } catch (e: any) {
+      toast({ variant: "destructive", title: "操作失败", description: e.message });
+    }
+  }
+
+  async function handleDeleteRegistry(reg: any) {
+    if (!confirm(`确定删除 Registry "${reg.name}"？`)) return;
+    try {
+      await api.deleteRegistry(reg.id);
+      const r = await api.getRegistries();
+      setRegistries(r || []);
+      toast({ title: "已删除" });
+    } catch (e: any) {
+      toast({ variant: "destructive", title: "删除失败", description: e.message });
+    }
+  }
+
+  return (
+    <Card className="border-border/50 bg-card/50 rounded-[2rem]">
+      <CardHeader>
+        <CardTitle>Registry 配置</CardTitle>
+        <CardDescription>管理应用市场 Registry 来源。</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Expose toggle */}
+        <div className="flex items-center justify-between p-3 rounded-xl bg-muted/20 border border-border/50">
+          <div>
+            <p className="text-sm font-medium">对外暴露 Registry</p>
+            <p className="text-xs text-muted-foreground">允许其他 Hub 从此实例拉取应用</p>
+          </div>
+          <Button
+            variant={registryConfig?.enabled === "true" ? "default" : "outline"}
+            size="sm"
+            onClick={handleToggleExpose}
+            disabled={saving}
+          >
+            {registryConfig?.enabled === "true" ? "已启用" : "已禁用"}
+          </Button>
+        </div>
+
+        {/* Registry Sources */}
+        <div className="space-y-2">
+          <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground">Registry 来源</p>
+          {registries.length === 0 ? (
+            <p className="text-xs text-muted-foreground py-2">暂无 Registry 来源</p>
+          ) : (
+            registries.map((reg) => (
+              <div key={reg.id} className="flex items-center justify-between p-2.5 rounded-lg border bg-background">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium truncate">{reg.name}</p>
+                  <p className="text-xs text-muted-foreground font-mono truncate">{reg.url}</p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <Button
+                    variant={reg.enabled ? "default" : "outline"}
+                    size="sm"
+                    className="h-7 text-xs"
+                    onClick={() => handleToggleRegistry(reg)}
+                  >
+                    {reg.enabled ? "启用" : "禁用"}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs text-destructive"
+                    onClick={() => handleDeleteRegistry(reg)}
+                    aria-label="删除"
+                  >
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </Button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Add Registry */}
+        <div className="space-y-2 pt-2 border-t">
+          <p className="text-xs font-bold uppercase tracking-widest text-muted-foreground">添加 Registry</p>
+          <div className="flex gap-2">
+            <Input
+              placeholder="名称"
+              value={newName}
+              onChange={e => setNewName(e.target.value)}
+              className="rounded-xl h-9 flex-1"
+            />
+            <Input
+              placeholder="URL"
+              value={newUrl}
+              onChange={e => setNewUrl(e.target.value)}
+              className="rounded-xl h-9 flex-[2]"
+            />
+            <Button
+              size="sm"
+              onClick={handleAddRegistry}
+              disabled={adding || !newName.trim() || !newUrl.trim()}
+              className="h-9 rounded-xl"
+            >
+              <Plus className="w-3.5 h-3.5 mr-1" /> 添加
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/web/src/pages/admin-reviews.tsx
+++ b/web/src/pages/admin-reviews.tsx
@@ -55,10 +55,10 @@ export function AdminReviewsPage() {
                   <TableCell className="font-bold">{a.name}</TableCell>
                   <TableCell className="font-mono text-xs opacity-60">{a.slug}</TableCell>
                   <TableCell className="text-xs">{a.owner_username}</TableCell>
-                  <TableCell><Badge variant={a.listed ? "default" : "secondary"}>{a.listed ? "已上架" : "待上架"}</Badge></TableCell>
+                  <TableCell><Badge variant={a.listing === "listed" ? "default" : "secondary"}>{a.listing === "listed" ? "已上架" : "待上架"}</Badge></TableCell>
                   <TableCell className="text-right">
-                    <Button variant="ghost" size="sm" onClick={async () => { await api.setAppListed(a.id, !a.listed); loadApps(); }}>
-                      {a.listed ? "下架" : "上架"}
+                    <Button variant="ghost" size="sm" onClick={async () => { const newListing = a.listing === "listed" ? "unlisted" : "listed"; await api.setAppListing(a.id, newListing); loadApps(); }}>
+                      {a.listing === "listed" ? "下架" : "上架"}
                     </Button>
                   </TableCell>
                 </TableRow>

--- a/web/src/pages/app-detail.tsx
+++ b/web/src/pages/app-detail.tsx
@@ -71,11 +71,12 @@ export function AppDetailPage() {
         <Badge variant={app.status === "active" ? "default" : "outline"}>
           {app.status === "active" ? "已启用" : "草稿"}
         </Badge>
-        {app.listed ? (
+        {app.registry && <Badge variant="outline">来自应用市场</Badge>}
+        {app.listing === "listed" ? (
           <Badge variant="default">已上架</Badge>
-        ) : app.listing_status === "pending" ? (
+        ) : app.listing === "pending" ? (
           <Badge variant="outline">审核中</Badge>
-        ) : app.listing_status === "rejected" ? (
+        ) : app.listing === "rejected" ? (
           <Badge variant="destructive">已拒绝</Badge>
         ) : null}
       </div>
@@ -174,10 +175,11 @@ function BasicInfoSection({ app, onUpdate }: { app: any; onUpdate: () => void })
       <Card className="space-y-3">
         <h3 className="text-sm font-medium">展示信息</h3>
         <form onSubmit={handleSave} className="space-y-2">
-          <Input placeholder="名称" value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} className="h-8 text-xs" />
-          <Input placeholder="描述" value={form.description} onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))} className="h-8 text-xs" />
-          <Input placeholder="图标 (emoji 或 URL)" value={form.icon} onChange={(e) => setForm((f) => ({ ...f, icon: e.target.value }))} className="h-8 text-xs" />
-          <Input placeholder="主页 URL" value={form.homepage} onChange={(e) => setForm((f) => ({ ...f, homepage: e.target.value }))} className="h-8 text-xs" />
+          <Input placeholder="名称" value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} className="h-8 text-xs" disabled={!!app.registry} />
+          <Input placeholder="描述" value={form.description} onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))} className="h-8 text-xs" disabled={!!app.registry} />
+          <Input placeholder="图标 (emoji 或 URL)" value={form.icon} onChange={(e) => setForm((f) => ({ ...f, icon: e.target.value }))} className="h-8 text-xs" disabled={!!app.registry} />
+          <Input placeholder="主页 URL" value={form.homepage} onChange={(e) => setForm((f) => ({ ...f, homepage: e.target.value }))} className="h-8 text-xs" disabled={!!app.registry} />
+          {!app.registry && (
           <div className="flex items-center justify-between">
             <div>
               {error && <span className="text-xs text-destructive">{error}</span>}
@@ -185,20 +187,58 @@ function BasicInfoSection({ app, onUpdate }: { app: any; onUpdate: () => void })
             </div>
             <Button type="submit" size="sm" disabled={saving}>{saving ? "..." : "保存"}</Button>
           </div>
+          )}
         </form>
       </Card>
+
+      {/* Registry badge */}
+      {app.registry && (
+        <Card className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Badge variant="outline">来自应用市场</Badge>
+            <span className="text-xs text-muted-foreground">此应用来自应用市场 Registry，配置不可编辑。</span>
+          </div>
+        </Card>
+      )}
+
+      {/* Integration Token Guide */}
+      {app.kind === "integration" && (
+        <IntegrationTokenGuide app={app} />
+      )}
+
+      {/* Readme */}
+      {app.readme && (
+        <Card className="space-y-3">
+          <h3 className="text-sm font-medium">说明文档</h3>
+          <div className="text-sm text-muted-foreground whitespace-pre-wrap font-mono leading-relaxed">
+            {app.readme.replace(/\{hub_url\}/g, window.location.origin).replace(/\{your_token\}/g, "<your_token>")}
+          </div>
+        </Card>
+      )}
+
+      {app.kind === "integration" && !app.readme && (
+        <Card className="space-y-3">
+          <h3 className="text-sm font-medium">使用说明</h3>
+          <p className="text-xs text-muted-foreground">此应用为 Integration 类型，使用 Token 进行 API 调用。请在安装管理中查看 Token。</p>
+          <div className="space-y-2 text-xs font-mono text-muted-foreground">
+            <p className="font-sans text-xs font-medium text-foreground">HTTP 发消息</p>
+            <pre className="p-2 rounded-lg bg-muted/30 border overflow-x-auto whitespace-pre-wrap">{`curl -X POST ${window.location.origin}/bot/v1/message/send \\
+  -H "Authorization: Bearer <your_token>" \\
+  -d '{"to":"wxid_xxx","content":"hello"}'`}</pre>
+            <p className="font-sans text-xs font-medium text-foreground">WebSocket 连接</p>
+            <pre className="p-2 rounded-lg bg-muted/30 border overflow-x-auto whitespace-pre-wrap">{`wss://${window.location.origin.replace(/^https?:\/\//, "")}/bot/v1/ws?token=<your_token>`}</pre>
+          </div>
+        </Card>
+      )}
 
       {/* App Credentials */}
       <Card className="space-y-4">
         <h3 className="text-sm font-medium">应用凭证</h3>
         <p className="text-xs text-muted-foreground">这些凭证用于你的 App 与 Hub 之间的安全通信。请妥善保管，不要泄露。</p>
-        {app.client_secret && (
-          <SecretField label="Client Secret" value={app.client_secret} description="用于 OAuth 流程中验证 App 身份" />
+        {app.webhook_secret && (
+          <SecretField label="Webhook Secret" value={app.webhook_secret} description="Hub 使用此密钥对推送事件签名，App 用它验证请求来源" />
         )}
-        {app.signing_secret && (
-          <SecretField label="Signing Secret" value={app.signing_secret} description="Hub 使用此密钥对推送事件签名，App 用它验证请求来源" />
-        )}
-        {!app.client_secret && !app.signing_secret && (
+        {!app.webhook_secret && (
           <p className="text-xs text-muted-foreground italic">凭证仅对 App 所有者可见。</p>
         )}
       </Card>
@@ -212,6 +252,29 @@ function BasicInfoSection({ app, onUpdate }: { app: any; onUpdate: () => void })
         </Button>
       </Card>
     </div>
+  );
+}
+
+function IntegrationTokenGuide({ app }: { app: any }) {
+  const hubUrl = window.location.origin;
+
+  return (
+    <Card className="space-y-4">
+      <h3 className="text-sm font-medium">Integration Token 使用指南</h3>
+      <p className="text-xs text-muted-foreground">此应用为 Integration 类型。安装实例的 Token 可在「安装管理」中查看。</p>
+      <div className="space-y-3 text-xs">
+        <div className="space-y-1">
+          <p className="font-medium text-foreground">HTTP 发消息</p>
+          <pre className="p-2 rounded-lg bg-muted/30 border font-mono overflow-x-auto whitespace-pre-wrap">{`curl -X POST ${hubUrl}/bot/v1/message/send \\
+  -H "Authorization: Bearer {token}" \\
+  -d '{"to":"wxid_xxx","content":"hello"}'`}</pre>
+        </div>
+        <div className="space-y-1">
+          <p className="font-medium text-foreground">WebSocket 连接</p>
+          <pre className="p-2 rounded-lg bg-muted/30 border font-mono overflow-x-auto whitespace-pre-wrap">{`wss://${hubUrl.replace(/^https?:\/\//, "")}/bot/v1/ws?token={token}`}</pre>
+        </div>
+      </div>
+    </Card>
   );
 }
 
@@ -373,19 +436,19 @@ function DistributionSection({ app, onUpdate }: { app: any; onUpdate: () => void
       <Card className="space-y-4">
         <h3 className="text-sm font-medium">应用市场</h3>
 
-        {app.listed ? (
+        {app.listing === "listed" ? (
           <div className="flex items-center gap-2">
             <Badge variant="default">已上架</Badge>
             <span className="text-xs text-muted-foreground">你的应用已在应用市场中展示。</span>
           </div>
-        ) : app.listing_status === "pending" ? (
+        ) : app.listing === "pending" ? (
           <div className="space-y-2">
             <div className="flex items-center gap-2">
               <Badge variant="outline">审核中</Badge>
               <span className="text-xs text-muted-foreground">上架申请已提交，等待管理员审核。</span>
             </div>
           </div>
-        ) : app.listing_status === "rejected" ? (
+        ) : app.listing === "rejected" ? (
           <div className="space-y-3">
             <div className="flex items-center gap-2">
               <Badge variant="destructive">已拒绝</Badge>
@@ -413,7 +476,7 @@ function DistributionSection({ app, onUpdate }: { app: any; onUpdate: () => void
 // ==================== Event Subscriptions ====================
 
 function EventSubscriptionsSection({ app, onUpdate }: { app: any; onUpdate: () => void }) {
-  const [requestUrl, setRequestUrl] = useState(app.request_url || "");
+  const [webhookUrl, setWebhookUrl] = useState(app.webhook_url || "");
   const [events, setEvents] = useState<string[]>(app.events || []);
   const [saving, setSaving] = useState(false);
   const [verifying, setVerifying] = useState(false);
@@ -426,7 +489,7 @@ function EventSubscriptionsSection({ app, onUpdate }: { app: any; onUpdate: () =
   async function handleSave() {
     setSaving(true);
     try {
-      await api.updateApp(app.id, { request_url: requestUrl, events });
+      await api.updateApp(app.id, { webhook_url: webhookUrl, events });
       toast({ title: "已保存" });
       onUpdate();
     } catch (e: any) {
@@ -438,8 +501,8 @@ function EventSubscriptionsSection({ app, onUpdate }: { app: any; onUpdate: () =
   async function handleVerify() {
     setVerifying(true);
     try {
-      if (requestUrl !== (app.request_url || "")) {
-        await api.updateApp(app.id, { request_url: requestUrl });
+      if (webhookUrl !== (app.webhook_url || "")) {
+        await api.updateApp(app.id, { webhook_url: webhookUrl });
       }
       await api.verifyAppUrl(app.id);
       toast({ title: "URL 验证成功" });
@@ -463,11 +526,11 @@ function EventSubscriptionsSection({ app, onUpdate }: { app: any; onUpdate: () =
         <div className="flex gap-2">
           <Input
             placeholder="https://your-app.example.com/webhook"
-            value={requestUrl}
-            onChange={(e) => setRequestUrl(e.target.value)}
+            value={webhookUrl}
+            onChange={(e) => setWebhookUrl(e.target.value)}
             className="h-8 text-xs font-mono flex-1"
           />
-          <Button size="sm" variant="outline" onClick={handleVerify} disabled={verifying || !requestUrl.trim()} className="h-8">
+          <Button size="sm" variant="outline" onClick={handleVerify} disabled={verifying || !webhookUrl.trim()} className="h-8">
             {verifying ? <Loader2 className="h-3 w-3 animate-spin" /> : <ExternalLink className="h-3 w-3 mr-1" />}
             验证
           </Button>

--- a/web/src/pages/apps.tsx
+++ b/web/src/pages/apps.tsx
@@ -21,6 +21,9 @@ import {
   Eye,
   ExternalLink,
   Rocket,
+  Copy,
+  Check,
+  RefreshCw,
 } from "lucide-react";
 import { api } from "../lib/api";
 import { SCOPE_DESCRIPTIONS } from "../lib/constants";
@@ -46,10 +49,102 @@ function slugify(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9\u4e00-\u9fff]+/g, "-").replace(/^-|-$/g, "").slice(0, 32);
 }
 
+function randomSuffix(): string {
+  return Math.random().toString(36).slice(2, 8);
+}
+
+// ==================== Templates ====================
+
+const TEMPLATES = [
+  {
+    id: "websocket-app",
+    emoji: "\u{1F4E1}",
+    name: "WebSocket App",
+    description: "\u901A\u8FC7 WebSocket \u5B9E\u65F6\u6536\u53D1 Bot \u6D88\u606F",
+    scopes: ["message:write", "message:read", "contact:read", "bot:read"],
+    events: ["message"],
+    readme: `## WebSocket App
+
+\u8FDE\u63A5 WebSocket \u5B9E\u65F6\u6536\u53D1\u6D88\u606F\u3002
+
+### \u8FDE\u63A5\u65B9\u5F0F
+
+\`\`\`
+wss://{hub_url}/bot/v1/ws?token={your_token}
+\`\`\`
+
+### \u53D1\u9001\u6D88\u606F
+
+\u901A\u8FC7 WebSocket \u53D1\u9001\uFF1A
+\`\`\`json
+{"type":"send","to":"wxid_xxx","content":"hello"}
+\`\`\`
+
+\u6216\u901A\u8FC7 HTTP\uFF1A
+\`\`\`bash
+curl -X POST {hub_url}/bot/v1/message/send \\
+  -H "Authorization: Bearer {your_token}" \\
+  -d '{"to":"wxid_xxx","content":"hello"}'
+\`\`\``,
+  },
+  {
+    id: "webhook-app",
+    emoji: "\u{1F517}",
+    name: "Webhook App",
+    description: "\u901A\u8FC7 HTTP API \u5411 Bot \u53D1\u9001\u6D88\u606F",
+    scopes: ["message:write"],
+    events: [],
+    readme: `## Webhook App
+
+\u901A\u8FC7 HTTP API \u53D1\u9001\u6D88\u606F\u3002
+
+### \u53D1\u9001\u6D88\u606F
+
+\`\`\`bash
+curl -X POST {hub_url}/bot/v1/message/send \\
+  -H "Authorization: Bearer {your_token}" \\
+  -H "Content-Type: application/json" \\
+  -d '{"to":"wxid_xxx","content":"hello"}'
+\`\`\`
+
+### \u53D1\u9001\u56FE\u7247
+
+\`\`\`bash
+curl -X POST {hub_url}/bot/v1/message/send \\
+  -H "Authorization: Bearer {your_token}" \\
+  -d '{"to":"wxid_xxx","type":"image","url":"https://example.com/img.png"}'
+\`\`\``,
+  },
+  {
+    id: "openclaw-channel",
+    emoji: "\u{1F99E}",
+    name: "OpenClaw Channel",
+    description: "\u901A\u8FC7 OpenClaw \u534F\u8BAE\u63A5\u5165 Bot",
+    scopes: ["message:write", "message:read", "contact:read", "bot:read"],
+    events: ["message"],
+    readme: `## OpenClaw Channel
+
+\u901A\u8FC7 OpenClaw Channel Plugin \u63A5\u5165 Bot\u3002
+
+### \u5B89\u88C5 Plugin
+
+\u8BF7\u53C2\u8003 [OpenClaw Channel Plugin \u6587\u6863](https://github.com/nicepkg/openclaw) \u5B89\u88C5\u548C\u914D\u7F6E\u3002
+
+### \u914D\u7F6E
+
+\u5728 OpenClaw \u914D\u7F6E\u4E2D\u586B\u5165\u4EE5\u4E0B\u4FE1\u606F\uFF1A
+
+- **Hub URL**: \`{hub_url}\`
+- **Token**: \`{your_token}\``,
+  },
+];
+
+// ==================== Page ====================
+
 export function AppsPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  
+
   const activeTab = location.pathname.split("/").pop() || "my";
   const tab = activeTab === "marketplace" ? "marketplace" : "my";
 
@@ -61,16 +156,16 @@ export function AppsPage() {
             <Blocks className="h-6 w-6" />
           </div>
           <div>
-            <h2 className="text-3xl font-bold tracking-tight">应用</h2>
-            <p className="text-muted-foreground">管理和安装应用。</p>
+            <h2 className="text-3xl font-bold tracking-tight">\u5E94\u7528</h2>
+            <p className="text-muted-foreground">\u7BA1\u7406\u548C\u5B89\u88C5\u5E94\u7528\u3002</p>
           </div>
         </div>
       </div>
 
       <Tabs value={tab} onValueChange={(v) => navigate(`/dashboard/apps/${v}`)}>
         <TabsList>
-          <TabsTrigger value="my">我的应用</TabsTrigger>
-          <TabsTrigger value="marketplace">应用市场</TabsTrigger>
+          <TabsTrigger value="my">\u6211\u7684\u5E94\u7528</TabsTrigger>
+          <TabsTrigger value="marketplace">\u5E94\u7528\u5E02\u573A</TabsTrigger>
         </TabsList>
         <TabsContent value="my" className="flex flex-col gap-6 mt-6">
           <MyAppsTab />
@@ -86,92 +181,172 @@ export function AppsPage() {
 // ==================== Marketplace (Store) ====================
 
 function MarketplaceTab() {
-  const [apps, setApps] = useState<any[]>([]);
+  const [marketplaceApps, setMarketplaceApps] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
-  const [installApp, setInstallApp] = useState<any>(null);
+  const [installTarget, setInstallTarget] = useState<{ type: "template"; template: typeof TEMPLATES[number] } | { type: "marketplace"; app: any } | null>(null);
   const [search, setSearch] = useState("");
 
   useEffect(() => {
     setLoading(true);
-    api.listApps({ listed: true }).then(l => setApps(l || [])).finally(() => setLoading(false));
+    api.getMarketplace().then(l => setMarketplaceApps(l || [])).catch(() => setMarketplaceApps([])).finally(() => setLoading(false));
   }, []);
 
-  const filtered = apps.filter(a =>
-    !search || a.name.toLowerCase().includes(search.toLowerCase()) || (a.slug || "").toLowerCase().includes(search.toLowerCase())
+  const filteredApps = marketplaceApps.filter(a =>
+    !search || a.name?.toLowerCase().includes(search.toLowerCase()) || (a.slug || "").toLowerCase().includes(search.toLowerCase())
   );
 
-  if (loading) return (
-    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {[1, 2, 3].map(i => <Card key={i} className="h-48 animate-pulse bg-muted/20 rounded-3xl" />)}
-    </div>
+  const filteredTemplates = TEMPLATES.filter(t =>
+    !search || t.name.toLowerCase().includes(search.toLowerCase()) || t.description.includes(search)
   );
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <div className="relative max-w-md">
         <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-        <Input placeholder="搜索应用..." value={search} onChange={e => setSearch(e.target.value)} className="pl-10 h-10 rounded-full bg-card shadow-sm border-border/50" aria-label="搜索应用" />
+        <Input placeholder="\u641C\u7D22\u5E94\u7528..." value={search} onChange={e => setSearch(e.target.value)} className="pl-10 h-10 rounded-full bg-card shadow-sm border-border/50" aria-label="\u641C\u7D22\u5E94\u7528" />
       </div>
 
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {filtered.map((app) => (
-          <Card key={app.id} className="group relative overflow-hidden rounded-[2rem] border-border/50 bg-card/50 transition-all hover:shadow-2xl hover:-translate-y-1">
-            <CardHeader className="pb-4">
-              <div className="flex items-start gap-4">
-                <AppIcon icon={app.icon} iconUrl={app.icon_url} />
-                <div className="min-w-0 space-y-1 pt-1">
-                  <CardTitle className="text-lg font-bold truncate group-hover:text-primary transition-colors">{app.name}</CardTitle>
-                  <div className="flex flex-wrap gap-1.5">
-                    <Badge variant="secondary" className="text-[9px] h-4 font-bold uppercase tracking-tighter bg-primary/5 text-primary border-none">
-                      {app.tools?.length || 0} 个工具
-                    </Badge>
-                    <Badge variant="outline" className="text-[9px] h-4 font-bold uppercase tracking-tighter opacity-60">
-                      {app.status}
-                    </Badge>
+      {/* Quick Create Templates */}
+      {filteredTemplates.length > 0 && (
+        <div className="space-y-4">
+          <h3 className="text-sm font-bold uppercase tracking-widest text-muted-foreground">\u5FEB\u901F\u521B\u5EFA</h3>
+          <div className="grid gap-4 md:grid-cols-3">
+            {filteredTemplates.map((tpl) => (
+              <Card key={tpl.id} className="group relative overflow-hidden rounded-2xl border-border/50 bg-card/50 transition-all hover:shadow-xl hover:-translate-y-0.5">
+                <CardHeader className="pb-3">
+                  <div className="flex items-center gap-3">
+                    <div className="h-10 w-10 rounded-xl bg-muted flex items-center justify-center text-xl border">
+                      {tpl.emoji}
+                    </div>
+                    <CardTitle className="text-base font-bold group-hover:text-primary transition-colors">{tpl.name}</CardTitle>
                   </div>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent className="pb-6">
-              <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2 min-h-[2.5rem]">
-                {app.description || "暂无描述"}
-              </p>
-            </CardContent>
-            <CardFooter className="bg-muted/30 pt-4 flex justify-between items-center px-6">
-              <span className="text-[10px] font-bold text-muted-foreground">{app.owner_name || app.slug}</span>
-              <Button size="sm" onClick={() => setInstallApp(app)} className="h-8 rounded-full px-4 gap-1.5 font-bold text-xs shadow-lg shadow-primary/10">
-                安装 <Download className="h-3 w-3" />
-              </Button>
-            </CardFooter>
-          </Card>
-        ))}
-        {filtered.length === 0 && apps.length > 0 && (
-          <p className="col-span-full text-center text-sm text-muted-foreground py-8">没有匹配的应用</p>
+                </CardHeader>
+                <CardContent className="pb-4">
+                  <p className="text-xs text-muted-foreground leading-relaxed">{tpl.description}</p>
+                </CardContent>
+                <CardFooter className="bg-muted/30 pt-3 flex justify-end px-6">
+                  <Button size="sm" variant="outline" onClick={() => setInstallTarget({ type: "template", template: tpl })} className="h-8 rounded-full px-4 gap-1.5 font-bold text-xs">
+                    \u5B89\u88C5 <Download className="h-3 w-3" />
+                  </Button>
+                </CardFooter>
+              </Card>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Marketplace Apps */}
+      <div className="space-y-4">
+        <h3 className="text-sm font-bold uppercase tracking-widest text-muted-foreground">\u5E94\u7528\u5E02\u573A</h3>
+        {loading ? (
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {[1, 2, 3].map(i => <Card key={i} className="h-48 animate-pulse bg-muted/20 rounded-3xl" />)}
+          </div>
+        ) : filteredApps.length === 0 ? (
+          <div className="text-center py-16 space-y-3 border-2 border-dashed rounded-2xl">
+            <Blocks className="w-10 h-10 mx-auto text-muted-foreground/40" />
+            <p className="text-sm text-muted-foreground">{search ? "\u6CA1\u6709\u5339\u914D\u7684\u5E94\u7528" : "\u5E02\u573A\u6682\u65E0\u5E94\u7528"}</p>
+          </div>
+        ) : (
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {filteredApps.map((app) => (
+              <Card key={app.slug || app.id} className="group relative overflow-hidden rounded-[2rem] border-border/50 bg-card/50 transition-all hover:shadow-2xl hover:-translate-y-1">
+                <CardHeader className="pb-4">
+                  <div className="flex items-start gap-4">
+                    <AppIcon icon={app.icon} iconUrl={app.icon_url} />
+                    <div className="min-w-0 space-y-1 pt-1">
+                      <CardTitle className="text-lg font-bold truncate group-hover:text-primary transition-colors">{app.name}</CardTitle>
+                      <div className="flex flex-wrap gap-1.5">
+                        {app.author && (
+                          <span className="text-[10px] text-muted-foreground">{app.author}</span>
+                        )}
+                        {app.version && (
+                          <Badge variant="outline" className="text-[9px] h-4 font-bold tracking-tighter opacity-60">
+                            v{app.version}
+                          </Badge>
+                        )}
+                        {app.installed && (
+                          <Badge variant="default" className="text-[9px] h-4 font-bold tracking-tighter">
+                            \u5DF2\u5B89\u88C5
+                          </Badge>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="pb-6">
+                  <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2 min-h-[2.5rem]">
+                    {app.description || "\u6682\u65E0\u63CF\u8FF0"}
+                  </p>
+                </CardContent>
+                <CardFooter className="bg-muted/30 pt-4 flex justify-between items-center px-6">
+                  <span className="text-[10px] font-bold text-muted-foreground">{app.author || app.slug}</span>
+                  {app.installed && app.update_available ? (
+                    <Button size="sm" variant="outline" onClick={() => setInstallTarget({ type: "marketplace", app })} className="h-8 rounded-full px-4 gap-1.5 font-bold text-xs">
+                      \u66F4\u65B0 <RefreshCw className="h-3 w-3" />
+                    </Button>
+                  ) : app.installed ? (
+                    <Badge variant="secondary" className="text-xs">\u5DF2\u5B89\u88C5</Badge>
+                  ) : (
+                    <Button size="sm" onClick={() => setInstallTarget({ type: "marketplace", app })} className="h-8 rounded-full px-4 gap-1.5 font-bold text-xs shadow-lg shadow-primary/10">
+                      \u5B89\u88C5 <Download className="h-3 w-3" />
+                    </Button>
+                  )}
+                </CardFooter>
+              </Card>
+            ))}
+          </div>
         )}
       </div>
 
-      {installApp && (
-        <Dialog open={!!installApp} onOpenChange={(o: boolean) => !o && setInstallApp(null)}>
+      {installTarget && (
+        <Dialog open={!!installTarget} onOpenChange={(o: boolean) => !o && setInstallTarget(null)}>
           <DialogContent className="sm:max-w-2xl rounded-[2rem]">
             <DialogHeader className="sr-only">
-              <DialogTitle>安装 {installApp.name}</DialogTitle>
-              <DialogDescription>查看权限并确认安装。</DialogDescription>
+              <DialogTitle>\u5B89\u88C5\u5E94\u7528</DialogTitle>
+              <DialogDescription>\u9009\u62E9\u8D26\u53F7\u5E76\u786E\u8BA4\u5B89\u88C5\u3002</DialogDescription>
             </DialogHeader>
-            <InstallFlowDialog app={installApp} onClose={() => setInstallApp(null)} />
+            <InstallFlowDialog target={installTarget} onClose={() => setInstallTarget(null)} />
           </DialogContent>
         </Dialog>
       )}
-
     </div>
   );
 }
 
-function InstallFlowDialog({ app, onClose }: { app: any; onClose: () => void }) {
+// ==================== Install Flow Dialog ====================
+
+type InstallTarget =
+  | { type: "template"; template: typeof TEMPLATES[number] }
+  | { type: "marketplace"; app: any };
+
+type InstallResult = {
+  appId: string;
+  appName: string;
+  token?: string;
+  kind?: string;
+  templateId?: string;
+  readme?: string;
+};
+
+function InstallFlowDialog({ target, onClose }: { target: InstallTarget; onClose: () => void }) {
   const [bots, setBots] = useState<any[]>([]);
   const [botId, setBotId] = useState("");
-  const [handle, setHandle] = useState(app.slug || "");
+  const [handle, setHandle] = useState("");
   const [saving, setSaving] = useState(false);
+  const [result, setResult] = useState<InstallResult | null>(null);
   const { toast } = useToast();
+
+  const isTemplate = target.type === "template";
+  const appName = isTemplate ? target.template.name : target.app.name;
+  const appDescription = isTemplate ? target.template.description : target.app.description;
+  const appEmoji = isTemplate ? target.template.emoji : undefined;
+  const appIcon = isTemplate ? undefined : target.app.icon;
+  const appIconUrl = isTemplate ? undefined : target.app.icon_url;
+  const scopes = isTemplate ? target.template.scopes : (target.app.scopes || []);
+  const events = isTemplate ? target.template.events : (target.app.events || []);
+  const readScopes = scopes.filter((s: string) => s.includes("read"));
+  const writeScopes = scopes.filter((s: string) => !s.includes("read"));
 
   useEffect(() => {
     api.listBots().then(l => {
@@ -180,43 +355,103 @@ function InstallFlowDialog({ app, onClose }: { app: any; onClose: () => void }) 
     });
   }, []);
 
+  useEffect(() => {
+    if (isTemplate) {
+      setHandle(target.template.id);
+    } else {
+      setHandle(target.app.slug || "");
+    }
+  }, [target]);
+
   async function handleInstall() {
     if (!botId) return;
     setSaving(true);
     try {
-      await api.installApp(app.id, { bot_id: botId, handle: handle.trim() || undefined });
-      toast({ title: "安装成功", description: `已安装 ${app.name}。` });
-      onClose();
+      if (isTemplate) {
+        // Step 1: Create a new integration app
+        const slug = `${target.template.id}-${randomSuffix()}`;
+        const created = await api.createApp({
+          name: target.template.name,
+          slug,
+          description: target.template.description,
+          icon: target.template.emoji,
+          kind: "integration",
+          scopes: target.template.scopes,
+          events: target.template.events,
+          readme: target.template.readme,
+        });
+        // Step 2: Install to bot
+        const installation = await api.installApp(created.id, {
+          bot_id: botId,
+          handle: handle.trim() || undefined,
+          scopes: target.template.scopes,
+        });
+        setResult({
+          appId: created.id,
+          appName: target.template.name,
+          token: installation.token,
+          kind: "integration",
+          templateId: target.template.id,
+          readme: target.template.readme,
+        });
+      } else {
+        // Marketplace app
+        const app = target.app;
+        let appId = app.local_id || app.id;
+        if (!appId) {
+          // Sync from marketplace first
+          const synced = await api.syncMarketplaceApp(app.slug);
+          appId = synced.id;
+        }
+        const installation = await api.installApp(appId, {
+          bot_id: botId,
+          handle: handle.trim() || undefined,
+          scopes: app.scopes,
+        });
+        setResult({
+          appId: appId,
+          appName: app.name,
+          token: installation.token,
+          kind: app.kind,
+        });
+      }
+      toast({ title: "\u5B89\u88C5\u6210\u529F", description: `\u5DF2\u5B89\u88C5 ${appName}\u3002` });
     } catch (e: any) {
-      toast({ variant: "destructive", title: "安装失败", description: e.message });
+      toast({ variant: "destructive", title: "\u5B89\u88C5\u5931\u8D25", description: e.message });
     }
     setSaving(false);
   }
 
-  const tools = (app.tools || []) as any[];
-  const events = (app.events || []) as string[];
-  const scopes = (app.scopes || []) as string[];
-  const readScopes = scopes.filter(s => s.includes("read"));
-  const writeScopes = scopes.filter(s => !s.includes("read"));
+  // ---- Result screen ----
+  if (result) {
+    return <InstallResultScreen result={result} onClose={onClose} />;
+  }
 
+  // ---- Install form ----
   return (
     <div className="py-2">
       <div className="flex flex-col sm:flex-row gap-6">
         {/* Left: App identity */}
         <div className="sm:w-2/5 space-y-4 sm:border-r sm:pr-6">
           <div className="flex items-center gap-3">
-            <AppIcon icon={app.icon} iconUrl={app.icon_url} size="h-14 w-14" />
+            {appEmoji ? (
+              <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center text-2xl border">{appEmoji}</div>
+            ) : (
+              <AppIcon icon={appIcon} iconUrl={appIconUrl} size="h-14 w-14" />
+            )}
             <div>
-              <h3 className="text-lg font-bold">{app.name}</h3>
-              <p className="text-xs text-muted-foreground font-mono">{app.slug}</p>
+              <h3 className="text-lg font-bold">{appName}</h3>
+              {!isTemplate && target.app.slug && (
+                <p className="text-xs text-muted-foreground font-mono">{target.app.slug}</p>
+              )}
             </div>
           </div>
-          {app.description && (
-            <p className="text-sm text-muted-foreground leading-relaxed">{app.description}</p>
+          {appDescription && (
+            <p className="text-sm text-muted-foreground leading-relaxed">{appDescription}</p>
           )}
-          {app.homepage && (
-            <a href={app.homepage} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">
-              <ExternalLink className="h-3 w-3" /> 应用主页
+          {!isTemplate && target.app.homepage && (
+            <a href={target.app.homepage} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline flex items-center gap-1">
+              <ExternalLink className="h-3 w-3" /> \u5E94\u7528\u4E3B\u9875
             </a>
           )}
         </div>
@@ -224,12 +459,12 @@ function InstallFlowDialog({ app, onClose }: { app: any; onClose: () => void }) 
         {/* Right: Permissions + config */}
         <div className="sm:w-3/5 space-y-5">
           <div className="space-y-3">
-            <h4 className="text-xs font-bold uppercase tracking-wider text-muted-foreground">此应用将能够：</h4>
+            <h4 className="text-xs font-bold uppercase tracking-wider text-muted-foreground">\u6B64\u5E94\u7528\u5C06\u80FD\u591F\uFF1A</h4>
 
             {readScopes.length > 0 && (
               <div className="space-y-1.5">
-                <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">查看</p>
-                {readScopes.map(s => (
+                <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">\u67E5\u770B</p>
+                {readScopes.map((s: string) => (
                   <div key={s} className="flex items-start gap-2 text-sm">
                     <Eye className="h-3.5 w-3.5 mt-0.5 text-muted-foreground shrink-0" />
                     <span>{SCOPE_DESCRIPTIONS[s] || s}</span>
@@ -240,8 +475,8 @@ function InstallFlowDialog({ app, onClose }: { app: any; onClose: () => void }) 
 
             {writeScopes.length > 0 && (
               <div className="space-y-1.5">
-                <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">操作</p>
-                {writeScopes.map(s => (
+                <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">\u64CD\u4F5C</p>
+                {writeScopes.map((s: string) => (
                   <div key={s} className="flex items-start gap-2 text-sm">
                     <Zap className="h-3.5 w-3.5 mt-0.5 text-primary shrink-0" />
                     <span>{SCOPE_DESCRIPTIONS[s] || s}</span>
@@ -250,49 +485,38 @@ function InstallFlowDialog({ app, onClose }: { app: any; onClose: () => void }) 
               </div>
             )}
 
-            {tools.length > 0 && (
-              <div className="space-y-1.5">
-                <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">命令</p>
-                <div className="flex flex-wrap gap-1.5">
-                  {tools.map((t: any) => (
-                    <Badge key={t.name} variant="secondary" className="font-mono text-xs">/{t.command || t.name}</Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-
             {events.length > 0 && (
               <div className="space-y-1.5">
-                <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">事件订阅</p>
+                <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">\u4E8B\u4EF6\u8BA2\u9605</p>
                 <div className="flex flex-wrap gap-1.5">
-                  {events.map(e => (
+                  {events.map((e: string) => (
                     <Badge key={e} variant="outline" className="font-mono text-[10px]">{e}</Badge>
                   ))}
                 </div>
               </div>
             )}
 
-            {scopes.length === 0 && tools.length === 0 && events.length === 0 && (
-              <p className="text-sm text-muted-foreground">接收 @mention 消息并执行响应。</p>
+            {scopes.length === 0 && events.length === 0 && (
+              <p className="text-sm text-muted-foreground">\u63A5\u6536 @mention \u6D88\u606F\u5E76\u6267\u884C\u54CD\u5E94\u3002</p>
             )}
           </div>
 
           <div className="space-y-3 pt-2 border-t">
             {bots.length === 0 ? (
-              <p className="text-sm text-muted-foreground py-2">请先创建一个账号，然后再安装应用。</p>
+              <p className="text-sm text-muted-foreground py-2">\u8BF7\u5148\u521B\u5EFA\u4E00\u4E2A\u8D26\u53F7\uFF0C\u7136\u540E\u518D\u5B89\u88C5\u5E94\u7528\u3002</p>
             ) : (
               <>
                 <div className="space-y-1.5">
-                  <label htmlFor="mp-install-bot" className="text-xs font-medium">安装到账号</label>
+                  <label htmlFor="mp-install-bot" className="text-xs font-medium">\u5B89\u88C5\u5230\u8D26\u53F7</label>
                   <select id="mp-install-bot" value={botId} onChange={e => setBotId(e.target.value)}
                     className="w-full h-9 px-3 rounded-lg border bg-background text-sm outline-none focus:ring-2 focus:ring-primary/20">
                     {bots.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}
                   </select>
                 </div>
                 <div className="space-y-1.5">
-                  <label htmlFor="mp-install-handle" className="text-xs font-medium">Handle</label>
-                  <Input id="mp-install-handle" value={handle} onChange={e => setHandle(e.target.value)} className="h-9 font-mono" placeholder="如 notify-prod" />
-                  <p className="text-[10px] text-muted-foreground">用户发送 @{handle || "handle"} 触发此应用</p>
+                  <label htmlFor="mp-install-handle" className="text-xs font-medium">Handle\uFF08\u53EF\u9009\uFF09</label>
+                  <Input id="mp-install-handle" value={handle} onChange={e => setHandle(e.target.value)} className="h-9 font-mono" placeholder="\u5982 notify-prod" />
+                  <p className="text-[10px] text-muted-foreground">\u7528\u6237\u53D1\u9001 @{handle || "handle"} \u89E6\u53D1\u6B64\u5E94\u7528</p>
                 </div>
               </>
             )}
@@ -301,11 +525,90 @@ function InstallFlowDialog({ app, onClose }: { app: any; onClose: () => void }) 
       </div>
 
       <div className="flex justify-end gap-2 pt-4 mt-4 border-t">
-        <Button variant="ghost" onClick={onClose}>取消</Button>
-        <Button onClick={handleInstall} disabled={saving || !botId || !handle.trim()} className="px-6">
+        <Button variant="ghost" onClick={onClose}>\u53D6\u6D88</Button>
+        <Button onClick={handleInstall} disabled={saving || !botId} className="px-6">
           {saving && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
-          允许并安装
+          \u5141\u8BB8\u5E76\u5B89\u88C5
         </Button>
+      </div>
+    </div>
+  );
+}
+
+// ==================== Install Result Screen ====================
+
+function InstallResultScreen({ result, onClose }: { result: InstallResult; onClose: () => void }) {
+  const navigate = useNavigate();
+  const [copied, setCopied] = useState(false);
+  const hubUrl = window.location.origin;
+
+  function handleCopy(text: string) {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  const isIntegration = result.kind === "integration";
+
+  return (
+    <div className="py-2 space-y-6">
+      <div className="text-center space-y-2">
+        <div className="h-16 w-16 rounded-full bg-primary/10 flex items-center justify-center mx-auto">
+          <Check className="h-8 w-8 text-primary" />
+        </div>
+        <h3 className="text-xl font-bold">\u5B89\u88C5\u6210\u529F</h3>
+        <p className="text-sm text-muted-foreground">{result.appName} \u5DF2\u5B89\u88C5\u3002</p>
+      </div>
+
+      {isIntegration && result.token && (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-xs font-bold uppercase tracking-widest text-muted-foreground">Token</label>
+            <div className="flex items-center gap-2 p-3 rounded-lg border bg-muted/30">
+              <code className="text-sm font-mono flex-1 break-all">{result.token}</code>
+              <button onClick={() => handleCopy(result.token!)} className="cursor-pointer text-muted-foreground hover:text-foreground shrink-0" aria-label="\u590D\u5236">
+                {copied ? <Check className="w-4 h-4 text-primary" /> : <Copy className="w-4 h-4" />}
+              </button>
+            </div>
+            <p className="text-[10px] text-destructive font-medium">\u8BF7\u5999\u5584\u4FDD\u7BA1\u6B64 Token\uFF0C\u5173\u95ED\u540E\u5C06\u65E0\u6CD5\u518D\u6B21\u67E5\u770B\u3002</p>
+          </div>
+
+          <div className="space-y-3">
+            <details className="group">
+              <summary className="text-sm font-medium cursor-pointer flex items-center gap-2 select-none">
+                <ArrowRight className="h-3.5 w-3.5 transition-transform group-open:rotate-90" />
+                HTTP \u53D1\u6D88\u606F
+              </summary>
+              <pre className="mt-2 p-3 rounded-lg bg-muted/30 border text-xs font-mono overflow-x-auto whitespace-pre-wrap">{`curl -X POST ${hubUrl}/bot/v1/message/send \\
+  -H "Authorization: Bearer ${result.token}" \\
+  -d '{"to":"wxid_xxx","content":"hello"}'`}</pre>
+            </details>
+
+            {(result.templateId === "websocket-app" || result.templateId === "openclaw-channel") && (
+              <details className="group">
+                <summary className="text-sm font-medium cursor-pointer flex items-center gap-2 select-none">
+                  <ArrowRight className="h-3.5 w-3.5 transition-transform group-open:rotate-90" />
+                  WebSocket \u8FDE\u63A5
+                </summary>
+                <pre className="mt-2 p-3 rounded-lg bg-muted/30 border text-xs font-mono overflow-x-auto whitespace-pre-wrap">{`wss://${hubUrl.replace(/^https?:\/\//, "")}/bot/v1/ws?token=${result.token}`}</pre>
+              </details>
+            )}
+          </div>
+        </div>
+      )}
+
+      {!isIntegration && (
+        <div className="text-center">
+          <p className="text-sm text-muted-foreground">\u5E94\u7528\u5DF2\u5B89\u88C5\u5230\u4F60\u7684\u8D26\u53F7\u3002</p>
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2 pt-2 border-t">
+        <Button variant="outline" onClick={() => { onClose(); navigate(`/dashboard/apps/${result.appId}`); }}>
+          \u67E5\u770B\u5E94\u7528\u8BE6\u60C5
+        </Button>
+        <Button onClick={onClose}>\u5B8C\u6210</Button>
       </div>
     </div>
   );
@@ -332,11 +635,11 @@ function MyAppsTab() {
     if (!form.name.trim()) return;
     try {
       await api.createApp(form);
-      toast({ title: "创建成功", description: "应用已创建。" });
+      toast({ title: "\u521B\u5EFA\u6210\u529F", description: "\u5E94\u7528\u5DF2\u521B\u5EFA\u3002" });
       setIsCreating(false);
       load();
     } catch (e: any) {
-      toast({ variant: "destructive", title: "创建失败", description: e.message });
+      toast({ variant: "destructive", title: "\u521B\u5EFA\u5931\u8D25", description: e.message });
     }
   }
 
@@ -353,16 +656,16 @@ function MyAppsTab() {
         <Dialog open={isCreating} onOpenChange={setIsCreating}>
           <DialogTrigger asChild>
             <Button className="rounded-full h-10 px-6 gap-2 shadow-lg shadow-primary/20">
-              <Plus className="h-4 w-4" /> 创建应用
+              <Plus className="h-4 w-4" /> \u521B\u5EFA\u5E94\u7528
             </Button>
           </DialogTrigger>
           <DialogContent className="rounded-[2rem]">
-            <DialogHeader><DialogTitle className="text-2xl font-bold">创建应用</DialogTitle><DialogDescription>填写基本信息。</DialogDescription></DialogHeader>
+            <DialogHeader><DialogTitle className="text-2xl font-bold">\u521B\u5EFA\u5E94\u7528</DialogTitle><DialogDescription>\u586B\u5199\u57FA\u672C\u4FE1\u606F\u3002</DialogDescription></DialogHeader>
             <form onSubmit={handleCreate} className="space-y-5 pt-4">
-               <div className="space-y-2"><label className="text-xs font-bold uppercase text-muted-foreground">名称</label><Input placeholder="例如: 通知助手" value={form.name} onChange={e => { const n = e.target.value; setForm({...form, name: n, slug: slugify(n)}); }} /></div>
-               <div className="space-y-2"><label className="text-xs font-bold uppercase text-muted-foreground">唯一标识</label><Input value={form.slug} onChange={e => setForm({...form, slug: e.target.value})} className="font-mono" /></div>
-               <div className="space-y-2"><label className="text-xs font-bold uppercase text-muted-foreground">描述</label><Input placeholder="这个应用是用来..." value={form.description} onChange={e => setForm({...form, description: e.target.value})} /></div>
-               <DialogFooter className="pt-4"><Button type="submit" className="w-full rounded-full h-11">创建</Button></DialogFooter>
+               <div className="space-y-2"><label className="text-xs font-bold uppercase text-muted-foreground">\u540D\u79F0</label><Input placeholder="\u4F8B\u5982: \u901A\u77E5\u52A9\u624B" value={form.name} onChange={e => { const n = e.target.value; setForm({...form, name: n, slug: slugify(n)}); }} /></div>
+               <div className="space-y-2"><label className="text-xs font-bold uppercase text-muted-foreground">\u552F\u4E00\u6807\u8BC6</label><Input value={form.slug} onChange={e => setForm({...form, slug: e.target.value})} className="font-mono" /></div>
+               <div className="space-y-2"><label className="text-xs font-bold uppercase text-muted-foreground">\u63CF\u8FF0</label><Input placeholder="\u8FD9\u4E2A\u5E94\u7528\u662F\u7528\u6765..." value={form.description} onChange={e => setForm({...form, description: e.target.value})} /></div>
+               <DialogFooter className="pt-4"><Button type="submit" className="w-full rounded-full h-11">\u521B\u5EFA</Button></DialogFooter>
             </form>
           </DialogContent>
         </Dialog>
@@ -379,23 +682,23 @@ function MyAppsTab() {
                   <p className="text-[10px] font-mono uppercase tracking-widest text-muted-foreground">{app.slug}</p>
                 </div>
               </div>
-              <Badge variant={app.status === "active" ? "default" : "secondary"} className="h-5 rounded-full text-[9px] px-2 font-bold">{app.status === "active" ? "已发布" : "草稿"}</Badge>
+              <Badge variant={app.status === "active" ? "default" : "secondary"} className="h-5 rounded-full text-[9px] px-2 font-bold">{app.status === "active" ? "\u5DF2\u53D1\u5E03" : "\u8349\u7A3F"}</Badge>
             </CardHeader>
             <CardFooter className="bg-muted/30 pt-3 flex justify-between items-center px-6">
-               <span className="text-[10px] font-bold text-muted-foreground flex items-center gap-1.5"><Rocket className="h-3 w-3" /> {app.tools?.length || 0} 个工具已配置</span>
+               <span className="text-[10px] font-bold text-muted-foreground flex items-center gap-1.5"><Rocket className="h-3 w-3" /> {app.tools?.length || 0} \u4E2A\u5DE5\u5177\u5DF2\u914D\u7F6E</span>
                <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:text-primary group-hover:translate-x-1 transition-all" />
             </CardFooter>
           </Card>
         ))}
-        
+
         {apps.length === 0 && (
           <div className="col-span-full py-24 border-2 border-dashed rounded-[2rem] flex flex-col items-center justify-center text-center bg-muted/5">
             <div className="h-20 w-20 rounded-3xl bg-background border shadow-sm flex items-center justify-center mb-6">
               <Blocks className="h-10 w-10 text-primary/40" />
             </div>
-            <h3 className="text-xl font-bold">还没有应用</h3>
-            <p className="text-muted-foreground mt-2 max-w-sm">创建你的第一个应用。</p>
-            <Button variant="outline" className="mt-8 h-11 px-8 rounded-full" onClick={() => setIsCreating(true)}>创建应用</Button>
+            <h3 className="text-xl font-bold">\u8FD8\u6CA1\u6709\u5E94\u7528</h3>
+            <p className="text-muted-foreground mt-2 max-w-sm">\u521B\u5EFA\u4F60\u7684\u7B2C\u4E00\u4E2A\u5E94\u7528\u3002</p>
+            <Button variant="outline" className="mt-8 h-11 px-8 rounded-full" onClick={() => setIsCreating(true)}>\u521B\u5EFA\u5E94\u7528</Button>
           </div>
         )}
       </div>

--- a/web/src/pages/bot-apps-tab.tsx
+++ b/web/src/pages/bot-apps-tab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Card, CardContent } from "../components/ui/card";
@@ -15,6 +16,7 @@ import {
 } from "@/components/ui/dialog";
 
 export function BotAppsTab({ botId }: { botId: string }) {
+  const navigate = useNavigate();
   const [installations, setInstallations] = useState<any[]>([]);
   const [showInstall, setShowInstall] = useState(false);
   const { toast } = useToast();
@@ -59,7 +61,7 @@ export function BotAppsTab({ botId }: { botId: string }) {
         <div className="text-center py-16 space-y-3 border-2 border-dashed rounded-2xl">
           <Blocks className="w-10 h-10 mx-auto text-muted-foreground/40" />
           <p className="text-sm text-muted-foreground">暂无安装的应用</p>
-          <Button variant="outline" size="sm" onClick={() => setShowInstall(true)}>
+          <Button variant="outline" size="sm" onClick={() => navigate("/dashboard/apps/marketplace")}>
             浏览应用市场
           </Button>
         </div>
@@ -121,7 +123,7 @@ function InstallDialog({ botId, open, onOpenChange, onInstalled }: {
   useEffect(() => {
     if (!open) { setConfirmApp(null); setSearch(""); return; }
     setLoading(true);
-    Promise.all([api.listApps(), api.listApps({ listed: true })]).then(([my, listed]) => {
+    Promise.all([api.listApps(), api.listApps({ listing: true })]).then(([my, listed]) => {
       const seen = new Set<string>();
       const merged: any[] = [];
       for (const a of [...(my || []), ...(listed || [])]) {

--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -39,7 +39,7 @@ export function OnboardingPage() {
     if (step !== 2 || !botId) return;
     setLoadingApps(true);
     Promise.all([
-      api.listApps({ listed: true }),
+      api.listApps({ listing: true }),
       api.listBotApps(botId),
     ]).then(([marketplace, installed]) => {
       setApps(marketplace || []);


### PR DESCRIPTION
## Summary

Frontend implementation for the App Marketplace feature (#43).

- **Marketplace page**: Quick-create templates (📡 WebSocket App, 🔗 Webhook App, 🦞 OpenClaw Channel) + registry apps, unified install flow
- **Install dialog**: Select bot → set handle → confirm scopes → install → show token + usage instructions
- **App detail**: Integration token guide, readme rendering, marketplace badge, editing disabled for registry apps
- **Admin settings**: Registry enable/disable toggle, registry source CRUD (add/enable/disable/delete)
- **Field updates**: All old field names and scope formats updated to match backend

## Test plan
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Go build passes
- [ ] Manual test: install WebSocket App template
- [ ] Manual test: install Webhook App template
- [ ] Manual test: app detail page shows token guide for integrations
- [ ] Manual test: admin registry config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added marketplace templates for quick app installation with pre-configured settings.
  * Introduced registry management dashboard with create, update, and delete capabilities.
  * Added installation result screen displaying integration tokens and command examples.

* **Improvements**
  * App listing now includes pending and rejected states in addition to listed/unlisted.
  * Registry-managed apps have read-only basic information fields.
  * Updated webhook URL configuration in event subscriptions.
  * Enhanced permission scope formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->