### PR TITLE
fix(web): improve session expired UX

### DIFF
--- a/internal/api/bot_handler.go
+++ b/internal/api/bot_handler.go
@@ -262,7 +262,7 @@ func (s *Server) handleReconnect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if bot.Status == "session_expired" {
-		jsonError(w, "session expired, please re-bind this bot", http.StatusConflict)
+		jsonError(w, "会话已过期，请先在微信中发送一条消息以恢复连接，若仍无法恢复请重新扫码绑定", http.StatusConflict)
 		return
 	}
 
@@ -364,7 +364,7 @@ func (s *Server) handleBotSend(w http.ResponseWriter, r *http.Request) {
 	inst, ok := s.BotManager.GetInstance(botID)
 	if !ok {
 		if bot.Status == "session_expired" {
-			jsonError(w, "会话已过期，请重新扫码绑定", http.StatusConflict)
+			jsonError(w, "会话已过期，请先在微信中发送一条消息以恢复连接，若仍无法恢复请重新扫码绑定", http.StatusConflict)
 		} else {
 			jsonError(w, "Bot 未连接", http.StatusServiceUnavailable)
 		}

--- a/web/src/pages/bots.tsx
+++ b/web/src/pages/bots.tsx
@@ -271,7 +271,7 @@ function BotInstanceCard({ bot, onRefresh, onRebind }: { bot: any; onRefresh: ()
             </div>
             <p className="text-[10px] text-muted-foreground pl-6">
               如果发送消息后仍无法恢复，请
-              <button className="underline text-destructive font-medium cursor-pointer" onClick={onRebind}>重新扫码绑定</button>
+              <button type="button" className="underline text-destructive font-medium cursor-pointer" onClick={onRebind}>重新扫码绑定</button>
               。
             </p>
           </div>


### PR DESCRIPTION
## Summary
- 会话过期时优先引导用户在微信中发送消息恢复连接，扫码绑定作为备选方案
- `session_expired` 状态下隐藏三点菜单中的「重新连接」按钮，避免触发无意义的 409 错误
- 后端 `checkSendStatus` 提示文案同步更新

## Test plan
- [ ] 模拟 bot session_expired 状态，检查卡片提示文案是否正确显示两步引导
- [ ] 确认三点菜单中「重新连接」在过期状态下不显示
- [ ] 确认「重新扫码绑定」链接可正常触发 rebind 流程
- [ ] 非过期状态下「重新连接」菜单项仍正常工作

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-expired messaging: instructs users to send a message in WeChat to attempt reconnection before re-scanning/re-binding.

* **UI Improvements**
  * Restructured session-expired display with clearer primary text and a muted hint linking to re-bind.
  * Removed the reconnect option when a session has expired to reduce confusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->