### PR TITLE
feat: per-installation tools

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1701,3 +1701,99 @@ func TestScopeSnapshotAtInstall(t *testing.T) {
 		}
 	})
 }
+
+// ---------------------------------------------------------------------------
+// Test: Bot API update installation tools
+// ---------------------------------------------------------------------------
+
+func TestBotAPI_UpdateInstallationTools(t *testing.T) {
+	env := setupTestEnv(t)
+	bot := createTestBot(t, env.store, env.user.ID, "inst-tools-bot")
+
+	// App with tools:write scope.
+	appWithScope := createTestApp(t, env.store, env.user.ID, "tools-app", "tools-app",
+		[]string{"tools:write"})
+	instWithScope := installTestApp(t, env.store, appWithScope.ID, bot.ID)
+
+	// App without tools:write scope.
+	appNoScope := createTestApp(t, env.store, env.user.ID, "no-tools-app", "no-tools-app",
+		[]string{"message:write"})
+	instNoScope := installTestApp(t, env.store, appNoScope.ID, bot.ID)
+
+	t.Run("update installation tools succeeds", func(t *testing.T) {
+		tools := []map[string]string{
+			{"name": "hn", "description": "Hacker News", "command": "hn"},
+			{"name": "weather", "description": "Weather report", "command": "weather"},
+		}
+		resp := doJSON(t, env.ts, "PUT", "/bot/v1/installation/tools",
+			map[string]any{"tools": tools},
+			withBearer(instWithScope.AppToken))
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body := decodeJSON(t, resp)
+			t.Fatalf("expected 200, got %d: %v", resp.StatusCode, body)
+		}
+		body := decodeJSON(t, resp)
+		if body["ok"] != true {
+			t.Errorf("expected ok=true, got %v", body["ok"])
+		}
+		if tc, _ := body["tool_count"].(float64); tc != 2 {
+			t.Errorf("expected tool_count=2, got %v", tc)
+		}
+
+		// Verify tools stored on installation (not app).
+		inst, err := env.store.GetInstallation(instWithScope.ID)
+		if err != nil {
+			t.Fatalf("GetInstallation: %v", err)
+		}
+		var storedTools []store.AppTool
+		if err := json.Unmarshal(inst.Tools, &storedTools); err != nil {
+			t.Fatalf("unmarshal tools: %v", err)
+		}
+		if len(storedTools) != 2 {
+			t.Errorf("expected 2 tools on installation, got %d", len(storedTools))
+		}
+
+		// App-level tools should remain unchanged (empty).
+		app, _ := env.store.GetApp(appWithScope.ID)
+		var appTools []store.AppTool
+		json.Unmarshal(app.Tools, &appTools)
+		if len(appTools) != 0 {
+			t.Errorf("app tools should be empty, got %d", len(appTools))
+		}
+	})
+
+	t.Run("missing tools:write scope returns 403", func(t *testing.T) {
+		resp := doJSON(t, env.ts, "PUT", "/bot/v1/installation/tools",
+			map[string]any{"tools": []any{}},
+			withBearer(instNoScope.AppToken))
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("expected 403, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("invalid tools format returns 400", func(t *testing.T) {
+		resp := doJSON(t, env.ts, "PUT", "/bot/v1/installation/tools",
+			map[string]any{"tools": "not-an-array"},
+			withBearer(instWithScope.AppToken))
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("missing tools field returns 400", func(t *testing.T) {
+		resp := doJSON(t, env.ts, "PUT", "/bot/v1/installation/tools",
+			map[string]any{},
+			withBearer(instWithScope.AppToken))
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/internal/api/app_skill.md
+++ b/internal/api/app_skill.md
@@ -430,14 +430,14 @@ Response:
 }
 ```
 
-### Update Tools
+### Update App Tools
 
 ```
 PUT /bot/v1/app/tools
 Authorization: Bearer {app_token}
 ```
 
-Dynamically update the app's tools/commands at runtime. Requires `tools:write` scope. Only works for local apps (not marketplace or builtin).
+Dynamically update the **app-level** tools/commands at runtime. Requires `tools:write` scope. Only works for local apps (not marketplace or builtin). App-level tools are shared across all installations of the app.
 
 | Field | Required | Description |
 |---|---|---|
@@ -446,6 +446,37 @@ Dynamically update the app's tools/commands at runtime. Requires `tools:write` s
 Response:
 ```json
 {"ok": true, "tool_count": 5}
+```
+
+### Update Installation Tools
+
+```
+PUT /bot/v1/installation/tools
+Authorization: Bearer {app_token}
+```
+
+Update **per-installation** tools/commands. Requires `tools:write` scope. Installation-level tools supplement the app-level tools -- during command matching, both sets are checked.
+
+Use this when different installations of the same app need different commands. For example, one installation might expose `/hn` while another exposes `/weather`.
+
+| Field | Required | Description |
+|---|---|---|
+| `tools` | Yes | JSON array of tool definitions |
+
+Response:
+```json
+{"ok": true, "tool_count": 2}
+```
+
+#### App-level vs Installation-level Tools
+
+```
+App.Tools = [/echo, /ping]              -- shared by all installations
+Installation.Tools = [/hn, /weather]     -- per-installation only
+
+Command matching merges both sets:
+  /echo    -> matched (from App)
+  /weather -> matched (from Installation)
 ```
 
 ### WebSocket (Per-Installation)
@@ -640,7 +671,8 @@ PUT /api/admin/config/registry
 | POST | `/bot/v1/message/send` | `message:write` | Send message |
 | GET | `/bot/v1/contact` | `contact:read` | List contacts |
 | GET | `/bot/v1/info` | `bot:read` | Get bot info |
-| PUT | `/bot/v1/app/tools` | `tools:write` | Update app tools dynamically |
+| PUT | `/bot/v1/app/tools` | `tools:write` | Update app-level tools dynamically |
+| PUT | `/bot/v1/installation/tools` | `tools:write` | Update per-installation tools |
 | GET | `/bot/v1/ws` | - | WebSocket (per-installation) |
 | GET | `/bot/v1/app/ws` | - | WebSocket (per-app, all installations) |
 

--- a/internal/api/bot_api.go
+++ b/internal/api/bot_api.go
@@ -422,6 +422,45 @@ func (s *Server) handleBotAPIUpdateTools(w http.ResponseWriter, r *http.Request)
 	json.NewEncoder(w).Encode(map[string]any{"ok": true, "tool_count": len(toolsCheck)})
 }
 
+// handleBotAPIUpdateInstallationTools handles PUT /bot/v1/installation/tools.
+// Updates this installation's per-installation tools. Requires tools:write scope.
+func (s *Server) handleBotAPIUpdateInstallationTools(w http.ResponseWriter, r *http.Request) {
+	inst := installationFromContext(r.Context())
+	if inst == nil {
+		botAPIError(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	if !s.requireScope(inst, "tools:write") {
+		botAPIError(w, "missing scope: tools:write", http.StatusForbidden)
+		return
+	}
+
+	var req struct {
+		Tools json.RawMessage `json:"tools"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Tools == nil {
+		botAPIError(w, "tools required", http.StatusBadRequest)
+		return
+	}
+
+	var toolsCheck []any
+	if err := json.Unmarshal(req.Tools, &toolsCheck); err != nil {
+		botAPIError(w, "tools must be a JSON array", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.Store.UpdateInstallationTools(inst.ID, req.Tools); err != nil {
+		botAPIError(w, "update failed", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Info("installation tools updated", "inst_id", inst.ID, "tool_count", len(toolsCheck))
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"ok": true, "tool_count": len(toolsCheck)})
+}
+
 func downloadURL(ctx context.Context, url string) ([]byte, string, error) {
 	dlCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -238,6 +238,7 @@ func (s *Server) Handler() http.Handler {
 	botAPI.HandleFunc("GET /bot/v1/contacts", s.handleBotAPIContacts)
 	botAPI.HandleFunc("GET /bot/v1/bot", s.handleBotAPIBotInfo)
 	botAPI.HandleFunc("PUT /bot/v1/app/tools", s.handleBotAPIUpdateTools)
+	botAPI.HandleFunc("PUT /bot/v1/installation/tools", s.handleBotAPIUpdateInstallationTools)
 	botAPI.HandleFunc("/bot/", s.handleBotAPINotFound)
 	mux.Handle("/bot/", s.appTokenAuth(botAPI))
 

--- a/internal/app/matching.go
+++ b/internal/app/matching.go
@@ -84,6 +84,12 @@ func (d *Dispatcher) MatchCommand(botID string, content string) ([]store.AppInst
 
 		if appHasCommand(app, command) {
 			matched = append(matched, inst)
+			continue
+		}
+
+		// Check installation-level tools
+		if instHasCommand(&inst, command) {
+			matched = append(matched, inst)
 		}
 	}
 
@@ -188,6 +194,26 @@ func appHasCommand(app *store.App, commandName string) bool {
 			continue
 		}
 		if strings.ToLower(tool.Command) == strings.ToLower(commandName) {
+			return true
+		}
+	}
+	return false
+}
+
+// instHasCommand checks whether an installation has a tool with a matching Command trigger.
+func instHasCommand(inst *store.AppInstallation, commandName string) bool {
+	if len(inst.Tools) == 0 || string(inst.Tools) == "[]" {
+		return false
+	}
+	var tools []store.AppTool
+	if err := json.Unmarshal(inst.Tools, &tools); err != nil {
+		return false
+	}
+	for _, t := range tools {
+		if t.Command == "" {
+			continue
+		}
+		if strings.ToLower(t.Command) == strings.ToLower(commandName) {
 			return true
 		}
 	}

--- a/internal/store/app.go
+++ b/internal/store/app.go
@@ -49,6 +49,7 @@ type AppInstallation struct {
 	Handle    string          `json:"handle,omitempty"`
 	Config    json.RawMessage `json:"config"`
 	Scopes    json.RawMessage `json:"scopes"`
+	Tools     json.RawMessage `json:"tools,omitempty"`
 	Enabled   bool            `json:"enabled"`
 	CreatedAt int64           `json:"created_at"`
 	UpdatedAt int64           `json:"updated_at"`
@@ -96,4 +97,5 @@ type AppStore interface {
 	WithdrawListing(id string) error
 	SetListing(id, listing string) error
 	UpdateAppTools(id string, tools json.RawMessage) error
+	UpdateInstallationTools(id string, tools json.RawMessage) error
 }

--- a/internal/store/postgres/app.go
+++ b/internal/store/postgres/app.go
@@ -245,10 +245,11 @@ func (db *DB) InstallApp(appID, botID string) (*store.AppInstallation, error) {
 		Scopes:   json.RawMessage("[]"),
 		Enabled:  true,
 	}
-	err := db.QueryRow(`INSERT INTO app_installations (id, app_id, bot_id, app_token, config, scopes)
-		VALUES ($1,$2,$3,$4,$5,$6)
+	inst.Tools = json.RawMessage("[]")
+	err := db.QueryRow(`INSERT INTO app_installations (id, app_id, bot_id, app_token, config, scopes, tools)
+		VALUES ($1,$2,$3,$4,$5,$6,$7)
 		RETURNING EXTRACT(EPOCH FROM created_at)::BIGINT, EXTRACT(EPOCH FROM updated_at)::BIGINT`,
-		inst.ID, inst.AppID, inst.BotID, inst.AppToken, inst.Config, inst.Scopes,
+		inst.ID, inst.AppID, inst.BotID, inst.AppToken, inst.Config, inst.Scopes, inst.Tools,
 	).Scan(&inst.CreatedAt, &inst.UpdatedAt)
 	return inst, err
 }
@@ -256,7 +257,7 @@ func (db *DB) InstallApp(appID, botID string) (*store.AppInstallation, error) {
 func (db *DB) GetInstallation(id string) (*store.AppInstallation, error) {
 	i := &store.AppInstallation{}
 	err := db.QueryRow(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled,
 		EXTRACT(EPOCH FROM i.created_at)::BIGINT, EXTRACT(EPOCH FROM i.updated_at)::BIGINT,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -264,7 +265,7 @@ func (db *DB) GetInstallation(id string) (*store.AppInstallation, error) {
 		FROM app_installations i JOIN apps a ON a.id = i.app_id
 		WHERE i.id = $1`, id).Scan(
 		&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-		&i.Handle, &i.Config, &i.Scopes, &i.Enabled,
+		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
 		&i.CreatedAt, &i.UpdatedAt,
 		&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 		&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -278,7 +279,7 @@ func (db *DB) GetInstallation(id string) (*store.AppInstallation, error) {
 func (db *DB) GetInstallationByToken(token string) (*store.AppInstallation, error) {
 	i := &store.AppInstallation{}
 	err := db.QueryRow(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled,
 		EXTRACT(EPOCH FROM i.created_at)::BIGINT, EXTRACT(EPOCH FROM i.updated_at)::BIGINT,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -286,7 +287,7 @@ func (db *DB) GetInstallationByToken(token string) (*store.AppInstallation, erro
 		FROM app_installations i JOIN apps a ON a.id = i.app_id
 		WHERE i.app_token = $1`, token).Scan(
 		&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-		&i.Handle, &i.Config, &i.Scopes, &i.Enabled,
+		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
 		&i.CreatedAt, &i.UpdatedAt,
 		&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 		&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -307,7 +308,7 @@ func (db *DB) ListInstallationsByBot(botID string) ([]store.AppInstallation, err
 
 func (db *DB) listInstallations(where string, arg any) ([]store.AppInstallation, error) {
 	rows, err := db.Query(fmt.Sprintf(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled,
 		EXTRACT(EPOCH FROM i.created_at)::BIGINT, EXTRACT(EPOCH FROM i.updated_at)::BIGINT,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -322,7 +323,7 @@ func (db *DB) listInstallations(where string, arg any) ([]store.AppInstallation,
 	for rows.Next() {
 		var i store.AppInstallation
 		if err := rows.Scan(&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-			&i.Handle, &i.Config, &i.Scopes, &i.Enabled,
+			&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
 			&i.CreatedAt, &i.UpdatedAt,
 			&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 			&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -359,7 +360,7 @@ func (db *DB) RegenerateInstallationToken(id string) (string, error) {
 func (db *DB) GetInstallationByHandle(botID, handle string) (*store.AppInstallation, error) {
 	i := &store.AppInstallation{}
 	err := db.QueryRow(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled,
 		EXTRACT(EPOCH FROM i.created_at)::BIGINT, EXTRACT(EPOCH FROM i.updated_at)::BIGINT,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -367,7 +368,7 @@ func (db *DB) GetInstallationByHandle(botID, handle string) (*store.AppInstallat
 		FROM app_installations i JOIN apps a ON a.id = i.app_id
 		WHERE i.bot_id = $1 AND i.handle = $2`, botID, handle).Scan(
 		&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-		&i.Handle, &i.Config, &i.Scopes, &i.Enabled,
+		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
 		&i.CreatedAt, &i.UpdatedAt,
 		&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 		&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -425,5 +426,10 @@ func (db *DB) SetListing(id, listing string) error {
 
 func (db *DB) UpdateAppTools(id string, tools json.RawMessage) error {
 	_, err := db.Exec(`UPDATE apps SET tools = $1, updated_at = NOW() WHERE id = $2`, tools, id)
+	return err
+}
+
+func (db *DB) UpdateInstallationTools(id string, tools json.RawMessage) error {
+	_, err := db.Exec(`UPDATE app_installations SET tools = $1, updated_at = NOW() WHERE id = $2`, tools, id)
 	return err
 }

--- a/internal/store/postgres/migrations/0031_installation_tools.sql
+++ b/internal/store/postgres/migrations/0031_installation_tools.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_installations ADD COLUMN tools JSONB NOT NULL DEFAULT '[]';

--- a/internal/store/sqlite/app.go
+++ b/internal/store/sqlite/app.go
@@ -248,9 +248,10 @@ func (db *DB) InstallApp(appID, botID string) (*store.AppInstallation, error) {
 		Scopes:   json.RawMessage("[]"),
 		Enabled:  true,
 	}
-	_, err := db.Exec(`INSERT INTO app_installations (id, app_id, bot_id, app_token, config, scopes)
-		VALUES (?,?,?,?,?,?)`,
-		inst.ID, inst.AppID, inst.BotID, inst.AppToken, inst.Config, inst.Scopes,
+	inst.Tools = json.RawMessage("[]")
+	_, err := db.Exec(`INSERT INTO app_installations (id, app_id, bot_id, app_token, config, scopes, tools)
+		VALUES (?,?,?,?,?,?,?)`,
+		inst.ID, inst.AppID, inst.BotID, inst.AppToken, inst.Config, inst.Scopes, inst.Tools,
 	)
 	if err != nil {
 		return nil, err
@@ -263,7 +264,7 @@ func (db *DB) InstallApp(appID, botID string) (*store.AppInstallation, error) {
 func (db *DB) GetInstallation(id string) (*store.AppInstallation, error) {
 	i := &store.AppInstallation{}
 	err := db.QueryRow(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled,
 		i.created_at, i.updated_at,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -271,7 +272,7 @@ func (db *DB) GetInstallation(id string) (*store.AppInstallation, error) {
 		FROM app_installations i JOIN apps a ON a.id = i.app_id
 		WHERE i.id = ?`, id).Scan(
 		&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-		&i.Handle, &i.Config, &i.Scopes, &i.Enabled,
+		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
 		&i.CreatedAt, &i.UpdatedAt,
 		&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 		&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -285,7 +286,7 @@ func (db *DB) GetInstallation(id string) (*store.AppInstallation, error) {
 func (db *DB) GetInstallationByToken(token string) (*store.AppInstallation, error) {
 	i := &store.AppInstallation{}
 	err := db.QueryRow(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled,
 		i.created_at, i.updated_at,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -293,7 +294,7 @@ func (db *DB) GetInstallationByToken(token string) (*store.AppInstallation, erro
 		FROM app_installations i JOIN apps a ON a.id = i.app_id
 		WHERE i.app_token = ?`, token).Scan(
 		&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-		&i.Handle, &i.Config, &i.Scopes, &i.Enabled,
+		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
 		&i.CreatedAt, &i.UpdatedAt,
 		&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 		&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -314,7 +315,7 @@ func (db *DB) ListInstallationsByBot(botID string) ([]store.AppInstallation, err
 
 func (db *DB) listInstallations(where string, arg any) ([]store.AppInstallation, error) {
 	rows, err := db.Query(fmt.Sprintf(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled,
 		i.created_at, i.updated_at,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -329,7 +330,7 @@ func (db *DB) listInstallations(where string, arg any) ([]store.AppInstallation,
 	for rows.Next() {
 		var i store.AppInstallation
 		if err := rows.Scan(&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-			&i.Handle, &i.Config, &i.Scopes, &i.Enabled,
+			&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
 			&i.CreatedAt, &i.UpdatedAt,
 			&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 			&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -366,7 +367,7 @@ func (db *DB) RegenerateInstallationToken(id string) (string, error) {
 func (db *DB) GetInstallationByHandle(botID, handle string) (*store.AppInstallation, error) {
 	i := &store.AppInstallation{}
 	err := db.QueryRow(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled,
 		i.created_at, i.updated_at,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -374,7 +375,7 @@ func (db *DB) GetInstallationByHandle(botID, handle string) (*store.AppInstallat
 		FROM app_installations i JOIN apps a ON a.id = i.app_id
 		WHERE i.bot_id = ? AND i.handle = ?`, botID, handle).Scan(
 		&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-		&i.Handle, &i.Config, &i.Scopes, &i.Enabled,
+		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
 		&i.CreatedAt, &i.UpdatedAt,
 		&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 		&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -445,5 +446,10 @@ func (db *DB) SetListing(id, listing string) error {
 
 func (db *DB) UpdateAppTools(id string, tools json.RawMessage) error {
 	_, err := db.Exec(`UPDATE apps SET tools = ?, updated_at = unixepoch() WHERE id = ?`, tools, id)
+	return err
+}
+
+func (db *DB) UpdateInstallationTools(id string, tools json.RawMessage) error {
+	_, err := db.Exec(`UPDATE app_installations SET tools = ?, updated_at = unixepoch() WHERE id = ?`, tools, id)
 	return err
 }

--- a/internal/store/sqlite/migrations/0001_initial.sql
+++ b/internal/store/sqlite/migrations/0001_initial.sql
@@ -220,6 +220,7 @@ CREATE TABLE IF NOT EXISTS app_installations (
     handle          TEXT NOT NULL DEFAULT '',
     config          TEXT NOT NULL DEFAULT '{}',
     scopes          TEXT NOT NULL DEFAULT '[]',
+    tools           TEXT NOT NULL DEFAULT '[]',
     enabled         INTEGER NOT NULL DEFAULT 1,
     created_at      INTEGER NOT NULL DEFAULT (unixepoch()),
     updated_at      INTEGER NOT NULL DEFAULT (unixepoch())

--- a/internal/store/storetest/app_lifecycle.go
+++ b/internal/store/storetest/app_lifecycle.go
@@ -497,6 +497,30 @@ func TestAppLifecycle(t *testing.T, s store.Store) {
 		}
 	})
 
+	t.Run("UpdateInstallationTools", func(t *testing.T) {
+		tools, _ := json.Marshal([]store.AppTool{
+			{Name: "hn", Command: "hn", Description: "Hacker News"},
+			{Name: "weather", Command: "weather", Description: "Weather report"},
+		})
+		if err := s.UpdateInstallationTools(instID, tools); err != nil {
+			t.Fatalf("UpdateInstallationTools: %v", err)
+		}
+		got, err := s.GetInstallation(instID)
+		if err != nil {
+			t.Fatalf("GetInstallation after UpdateInstallationTools: %v", err)
+		}
+		var gotTools []store.AppTool
+		if err := json.Unmarshal(got.Tools, &gotTools); err != nil {
+			t.Fatalf("unmarshal tools: %v", err)
+		}
+		if len(gotTools) != 2 {
+			t.Errorf("expected 2 tools, got %d", len(gotTools))
+		}
+		if gotTools[0].Command != "hn" {
+			t.Errorf("first tool command = %q, want %q", gotTools[0].Command, "hn")
+		}
+	})
+
 	t.Run("GetInstallationByHandle", func(t *testing.T) {
 		got, err := s.GetInstallationByHandle(b.ID, "my-app-handle")
 		if err != nil {


### PR DESCRIPTION
## Summary
- Add `Tools` field to `AppInstallation` struct, allowing installations to have their own tools in addition to the App's shared tools
- Add `PUT /bot/v1/installation/tools` API endpoint (requires `tools:write` scope) so apps can dynamically register per-installation commands
- Update command matching in `Dispatcher.MatchCommand` to merge both app-level and installation-level tools when resolving slash commands
- Add PostgreSQL migration (`0031_installation_tools.sql`), update SQLite schema, and update all installation SELECT/Scan queries in both store implementations

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] New API test `TestBotAPI_UpdateInstallationTools` covers: success, missing scope (403), invalid format (400), missing tools field (400)
- [x] New store test `UpdateInstallationTools` in `app_lifecycle.go` verifies round-trip persistence
- [ ] Manual: install an app, PUT installation tools, verify `/command` matching works for installation-level tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)