### PR TITLE
fix(migrations): remove invalid JSONB empty string comparison in migration 30

### DIFF
--- a/internal/store/postgres/migrations/0030_snapshot_scopes.sql
+++ b/internal/store/postgres/migrations/0030_snapshot_scopes.sql
@@ -4,4 +4,4 @@
 -- this migration handles existing installations created before that change.
 UPDATE app_installations SET scopes = (
     SELECT apps.scopes FROM apps WHERE apps.id = app_installations.app_id
-) WHERE scopes = '[]' OR scopes = '' OR scopes IS NULL;
+) WHERE scopes = '[]' OR scopes IS NULL;


### PR DESCRIPTION
## Problem / Intent

Migration 30 (`0030_snapshot_scopes.sql`) was failing on startup with:

```
ERROR: invalid input syntax for type json (SQLSTATE 22P02)
```

The condition `scopes = ''` compares a JSONB column to an empty string literal, which PostgreSQL cannot parse as JSON — causing the migration to abort and the service to fail to start.

## Approach

Remove the `scopes = ''` condition. A JSONB column can never hold an empty string value, so this condition was both invalid SQL and logically unreachable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the logic for updating app installation scopes in the database to target only installations with empty array or null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->