### PR TITLE
fix: tool 返回图片后跳过 LLM 二次处理

### DIFF
--- a/internal/sink/ai.go
+++ b/internal/sink/ai.go
@@ -414,7 +414,8 @@ func (s *AI) executeToolCall(ctx context.Context, d Delivery, tc ai.ToolCallRequ
 		span.SetAttr("tool.result", truncateStr(result.Reply, 500))
 	}
 
-	// Handle image replies: send image to user AND pass to LLM as multimodal content
+	// Handle image replies: send image to user directly.
+	// When all tool results in a round contain images, the caller skips LLM continuation.
 	if result.ReplyType == "image" {
 		images := s.resolveToolMedia(ctx, d.BotDBID, result)
 		// Only include images that were actually delivered to the user.


### PR DESCRIPTION
## Summary
- 当 tool call 返回图片时，图片已通过 `sendMediaToUser` 直接发送给用户
- 之前代码仍会调用 `ContinueWithToolResults` 让 LLM 再处理，导致 LLM 回复"抱歉，我无法提供图片"等无意义内容
- 现在检测到所有 tool 结果都包含图片时直接返回，避免多余的 LLM 调用和错误回复

## Test plan
- [ ] 配置一个会返回图片的 app tool，向 AI bot 发消息触发该 tool
- [ ] 验证 tool 返回图片后，用户只收到图片，不再收到 LLM 的多余文本回复
- [ ] 验证 tool 返回纯文本结果时，LLM 仍正常生成后续回复
- [ ] 验证混合场景：多个 tool call 中部分返回图片、部分返回文本时，LLM 仍继续处理

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Typing indicator now stops immediately when tool calls return images; reply content shows an image placeholder and the app skips further AI continuation.
* **Refactor**
  * Token-usage recording was streamlined into a single helper to ensure consistent tracking when tools produce results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->