### PR TITLE
feat(web): 事件日志点击跳转 trace 链路追踪页

### DIFF
--- a/web/src/pages/bot-traces-tab.tsx
+++ b/web/src/pages/bot-traces-tab.tsx
@@ -75,6 +75,7 @@ export function BotTracesTab({ botId }: { botId: string }) {
                   <TableCell><Skeleton className="h-4 w-10 ml-auto" /></TableCell>
                   <TableCell><Skeleton className="h-4 w-12 ml-auto" /></TableCell>
                   <TableCell><Skeleton className="h-4 w-20 ml-auto" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-4" /></TableCell>
                 </TableRow>
               ))
             ) : rootSpans.length === 0 ? (
@@ -92,8 +93,7 @@ export function BotTracesTab({ botId }: { botId: string }) {
                 return (
                   <TableRow
                     key={root.id}
-                    className="cursor-pointer group"
-                    role="link"
+                    className="cursor-pointer focus-visible:bg-muted/50"
                     tabIndex={0}
                     onClick={() => navigate(`/dashboard/accounts/${botId}/traces/${root.trace_id}`)}
                     onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); navigate(`/dashboard/accounts/${botId}/traces/${root.trace_id}`); } }}

--- a/web/src/pages/installation-detail.tsx
+++ b/web/src/pages/installation-detail.tsx
@@ -692,8 +692,7 @@ function EventLogsSection({ appId, instId, botId }: { appId: string; instId: str
               {logs.map((log) => (
                 <TableRow
                   key={log.id || log.trace_id + log.created_at}
-                  className={log.trace_id ? "cursor-pointer" : ""}
-                  role={log.trace_id ? "link" : undefined}
+                  className={log.trace_id ? "cursor-pointer focus-visible:bg-muted/50" : ""}
                   tabIndex={log.trace_id ? 0 : undefined}
                   onClick={() => log.trace_id && navigate(`/dashboard/accounts/${botId}/traces/${log.trace_id}`)}
                   onKeyDown={(e) => { if (log.trace_id && (e.key === "Enter" || e.key === " ")) { e.preventDefault(); navigate(`/dashboard/accounts/${botId}/traces/${log.trace_id}`); } }}


### PR DESCRIPTION
## Summary
- 事件投递日志表格整行可点击，跳转到对应的 trace 链路追踪详情页
- 有 `trace_id` 的行显示 cursor-pointer 和 hover 高亮，无 trace_id 的行不响应

## Test plan
- [ ] 打开应用安装详情页 → 事件日志 tab
- [ ] 点击有 trace_id 的日志行，确认跳转到正确的 trace 详情页
- [ ] 确认无 trace_id 的行不可点击

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event log rows are now clickable to navigate to trace details when a trace is available; rows without traces remain non-clickable.
  * Added a trailing column with a conditional chevron icon to indicate navigable rows.
  * Improved hover and cursor indicators for interactive rows.
  * Updated trace ID truncation to use a single-character ellipsis for clearer display.
  * Added keyboard support (Enter/Space) for activating navigable rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->