### PR TITLE
refactor: docker-compose 改用环境变量

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# Database
+POSTGRES_USER=openilink
+POSTGRES_PASSWORD=openilink
+POSTGRES_DB=openilink
+POSTGRES_PORT=15432
+
+# MinIO / Object Storage
+STORAGE_ACCESS_KEY=openilink
+STORAGE_SECRET_KEY=openilink
+STORAGE_BUCKET=openilink
+STORAGE_PUBLIC_URL=
+MINIO_API_PORT=19000
+MINIO_CONSOLE_PORT=19001
+
+# Hub
+HUB_PORT=9800
+RP_ORIGIN=http://localhost:9800
+RP_ID=localhost
+
+# OAuth (optional)
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+LINUXDO_CLIENT_ID=
+LINUXDO_CLIENT_SECRET=
+
+# Container settings
+RESTART_POLICY=on-failure
+
+# Traefik (production)
+TRAEFIK_ENABLE=false
+TRAEFIK_ENTRYPOINT=websecure
+TRAEFIK_CERTRESOLVER=letsencrypt
+
+# Network (set to traefik_default + true for production behind traefik)
+NETWORK_NAME=openilink-hub_default
+NETWORK_EXTERNAL=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,55 +2,74 @@ services:
   postgres:
     image: postgres:17-alpine
     environment:
-      POSTGRES_USER: openilink
-      POSTGRES_PASSWORD: openilink
-      POSTGRES_DB: openilink
+      POSTGRES_USER: ${POSTGRES_USER:-openilink}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-openilink}
+      POSTGRES_DB: ${POSTGRES_DB:-openilink}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U openilink -d openilink"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-openilink} -d ${POSTGRES_DB:-openilink}"]
       interval: 5s
       timeout: 5s
       retries: 10
     ports:
-      - "15432:5432"
+      - "${POSTGRES_PORT:-15432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+    restart: ${RESTART_POLICY:-on-failure}
+    networks:
+      - default
 
   minio:
     image: minio/minio
     command: server /data --console-address ":9001"
     environment:
-      MINIO_ROOT_USER: openilink
-      MINIO_ROOT_PASSWORD: openilink
+      MINIO_ROOT_USER: ${STORAGE_ACCESS_KEY:-openilink}
+      MINIO_ROOT_PASSWORD: ${STORAGE_SECRET_KEY:-openilink}
     ports:
-      - "19000:9000"
-      - "19001:9001"
+      - "${MINIO_API_PORT:-19000}:9000"
+      - "${MINIO_CONSOLE_PORT:-19001}:9001"
     volumes:
       - miniodata:/data
+    restart: ${RESTART_POLICY:-on-failure}
+    networks:
+      - default
 
   hub:
     build: .
-    restart: on-failure
+    restart: ${RESTART_POLICY:-on-failure}
     ports:
-      - "9800:9800"
+      - "${HUB_PORT:-9800}:9800"
     environment:
-      DATABASE_URL: postgres://openilink:openilink@postgres:5432/openilink?sslmode=disable
-      RP_ORIGIN: http://localhost:9800
-      RP_ID: localhost
+      DATABASE_URL: postgres://${POSTGRES_USER:-openilink}:${POSTGRES_PASSWORD:-openilink}@postgres:5432/${POSTGRES_DB:-openilink}?sslmode=disable
+      RP_ORIGIN: ${RP_ORIGIN:-http://localhost:9800}
+      RP_ID: ${RP_ID:-localhost}
       STORAGE_ENDPOINT: minio:9000
-      STORAGE_ACCESS_KEY: openilink
-      STORAGE_SECRET_KEY: openilink
-      STORAGE_BUCKET: openilink
-      # STORAGE_PUBLIC_URL: https://s3.example.com/openilink
-      # GITHUB_CLIENT_ID:
-      # GITHUB_CLIENT_SECRET:
-      # LINUXDO_CLIENT_ID:
-      # LINUXDO_CLIENT_SECRET:
+      STORAGE_ACCESS_KEY: ${STORAGE_ACCESS_KEY:-openilink}
+      STORAGE_SECRET_KEY: ${STORAGE_SECRET_KEY:-openilink}
+      STORAGE_BUCKET: ${STORAGE_BUCKET:-openilink}
+      STORAGE_PUBLIC_URL: ${STORAGE_PUBLIC_URL:-}
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
+      LINUXDO_CLIENT_ID: ${LINUXDO_CLIENT_ID:-}
+      LINUXDO_CLIENT_SECRET: ${LINUXDO_CLIENT_SECRET:-}
     depends_on:
       postgres:
         condition: service_healthy
       minio:
         condition: service_started
+    labels:
+      - traefik.enable=${TRAEFIK_ENABLE:-false}
+      - traefik.http.routers.hub.rule=Host(`${RP_ID:-localhost}`)
+      - traefik.http.routers.hub.entrypoints=${TRAEFIK_ENTRYPOINT:-websecure}
+      - traefik.http.routers.hub.tls.certresolver=${TRAEFIK_CERTRESOLVER:-letsencrypt}
+      - traefik.http.services.hub.loadbalancer.server.port=9800
+    networks:
+      - default
 
 volumes:
   pgdata:
   miniodata:
+
+networks:
+  default:
+    name: ${NETWORK_NAME:-openilink-hub_default}
+    external: ${NETWORK_EXTERNAL:-false}


### PR DESCRIPTION
## Summary
- docker-compose.yml 所有敏感/环境相关配置改用 `${VAR:-default}` 语法
- 本地开发零配置可用（默认值即开发环境配置）
- 生产环境通过 `.env` 文件覆盖密码、域名、网络等
- 新增 `.env.example` 作为配置参考
- 彻底解决 `git pull` 覆盖生产 docker-compose.yml 导致部署失败的问题

## Test plan
- [ ] 本地无 `.env` 文件时 `docker compose config` 验证通过
- [ ] 生产服务器创建 `.env` 后部署正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added example environment configuration file with baseline parameters for database, storage, networking, OAuth integration, and security settings.
  * Deployment configuration now parameterized via environment variables, allowing customization of service credentials, ports, and Traefik routing without modifying core configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->