### PR TITLE
refactor: docker-compose 环境变量化，收敛端口暴露

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - "${HUB_PORT:-9800}:9800"
     environment:
       DATABASE_URL: postgres://openilink:${PASSWORD:-openilink}@postgres:5432/openilink?sslmode=disable
-      RP_ORIGIN: ${RP_ORIGIN:-http://localhost:9800}
+      RP_ORIGIN: ${RP_ORIGIN:-http://localhost:${HUB_PORT:-9800}}
       RP_ID: ${RP_ID:-localhost}
       STORAGE_ENDPOINT: minio:9000
       STORAGE_ACCESS_KEY: openilink


### PR DESCRIPTION
## Summary
- 密码统一用 `POSTGRES_PASSWORD` 环境变量（默认 `openilink`），控制 pg、minio、hub 的 DATABASE_URL 和 STORAGE_SECRET_KEY
- 域名用 `RP_ORIGIN` / `RP_ID` 变量（默认 localhost）
- hub 端口用 `HUB_PORT` 变量（默认 9800），端口冲突时可通过 `.env` 或命令行覆盖
- pg 和 minio 不再暴露宿主机端口，仅容器网络内可访问；需要直连可用 `docker compose exec`

## Test plan
- [ ] 无 `.env` 时 `docker compose up` 正常启动
- [ ] `HUB_PORT=8080 docker compose up` 可自定义端口
- [ ] 确认 pg/minio 端口不再暴露到宿主机

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to support environment-specific credentials and port settings. Hard-coded passwords and fixed host port mappings were replaced with configurable values to improve security and deployment flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->