### PR TITLE
fix: app API/event log timestamps showing wrong date

### DIFF
--- a/web/src/pages/installation-detail.tsx
+++ b/web/src/pages/installation-detail.tsx
@@ -1017,10 +1017,10 @@ function StatusBadge({ status }: { status: number | string | undefined }) {
   );
 }
 
-function formatTime(ts: string | undefined): string {
+function formatTime(ts: number | undefined): string {
   if (!ts) return "-";
   try {
-    const d = new Date(ts);
+    const d = new Date(ts * 1000);
     return d.toLocaleString("zh-CN", {
       month: "2-digit",
       day: "2-digit",
@@ -1029,6 +1029,6 @@ function formatTime(ts: string | undefined): string {
       second: "2-digit",
     });
   } catch {
-    return ts;
+    return "-";
   }
 }


### PR DESCRIPTION
## Summary

- Fix `formatTime()` in `installation-detail.tsx`: Unix seconds were passed directly to `new Date()` which expects milliseconds
- Multiply by 1000 to match the pattern used everywhere else in the frontend
- Fix parameter type from `string` to `number`

Fixes #101

## Test plan

- [ ] Open an app installation detail page with API logs or event logs
- [ ] Verify timestamps show correct dates (not 1970-01-xx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp display to correctly interpret and format timestamp values, ensuring consistent and accurate presentation across the application.
  * Enhanced error handling to provide consistent fallback formatting when timestamp processing encounters issues, ensuring predictable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->