### PR TITLE
fix(web): 修复链路追踪属性面板换行显示问题

### DIFF
--- a/web/src/pages/trace-detail/span-detail.tsx
+++ b/web/src/pages/trace-detail/span-detail.tsx
@@ -204,7 +204,7 @@ export function SpanDetail({ span, open, onClose }: SpanDetailProps) {
                           {Object.entries(evt.attributes).map(([k, v]) => (
                             <div key={k} className="flex gap-2 text-[10px]">
                               <span className="text-blue-500 font-bold shrink-0">{k}:</span>
-                              <span className="text-foreground/70 break-all">{String(v)}</span>
+                              <span className="text-foreground/70 whitespace-pre-wrap break-words">{String(v)}</span>
                             </div>
                           ))}
                         </div>


### PR DESCRIPTION
## Summary
- 修复 Span 详情面板中 Attributes 值未正确处理换行的问题
- 添加 `whitespace-pre-wrap` 保留换行符，将 `break-all` 改为 `break-words` 改善换行效果

## Test plan
- [ ] 打开链路追踪详情页，查看包含换行符的属性值是否正确换行显示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved display of attribute and event values: preserves existing whitespace while enabling better line wrapping. Multi-line and formatted values are easier to read, long unbroken content wraps more naturally, and awkward mid-word breaks are reduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->