### PR TITLE
fix: validate to field in WebSocket send messages

### DIFF
--- a/internal/api/bot_api_ws.go
+++ b/internal/api/bot_api_ws.go
@@ -107,6 +107,11 @@ func (s *Server) HandleAppWSSend(conn *app.WSConn, msg map[string]any) {
 		return
 	}
 
+	if to == "" {
+		sendErr("to is required")
+		return
+	}
+
 	if msgType == "text" && content == "" {
 		sendErr("content is required for text messages")
 		return


### PR DESCRIPTION
## Summary

- Add validation for `to` field in `HandleAppWSSend` — return `"to is required"` error instead of silently sending to empty recipient
- Root cause of #102: `openilink-app-runner` was not passing `to` (sender ID) in WS send messages, fixed in openilink/openilink-app-runner@a4dbe67

Fixes #102

## Test plan

- [ ] WS send without `to` returns `{"type":"error","error":"to is required"}`
- [ ] WS send with `to` still works normally
- [ ] Runner v0.3.3+ sends replies successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message sending validation to require the recipient field and return descriptive error messages when not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->