### PR TITLE
fix: hide default registry import on official instance

### DIFF
--- a/web/src/pages/admin-overview.tsx
+++ b/web/src/pages/admin-overview.tsx
@@ -427,13 +427,12 @@ function RegistryConfigCard() {
           </p>
           {registries.length === 0 ? (
             <div className="flex items-center justify-between p-3 rounded-lg border border-dashed bg-muted/10">
-              <div>
-                <p className="text-sm text-muted-foreground">暂无 Registry 来源</p>
-                <p className="text-xs text-muted-foreground">添加官方 Registry 以浏览应用市场</p>
-              </div>
-              <Button size="sm" onClick={handleImportDefault} disabled={adding}>
-                <Globe className="w-3.5 h-3.5 mr-1" /> 一键导入官方源
-              </Button>
+              <p className="text-sm text-muted-foreground">暂无 Registry 来源</p>
+              {window.location.origin !== "https://hub.openilink.com" && (
+                <Button size="sm" onClick={handleImportDefault} disabled={adding}>
+                  <Globe className="w-3.5 h-3.5 mr-1" /> 一键导入官方源
+                </Button>
+              )}
             </div>
           ) : (
             registries.map((reg) => (


### PR DESCRIPTION
## Summary

- Hide the "一键导入官方源" button when `window.location.origin` is `https://hub.openilink.com` to avoid importing itself as a registry source

## Test plan

- [ ] On `hub.openilink.com`: empty registry shows only "暂无 Registry 来源", no import button
- [ ] On other instances (e.g. localhost:9800): shows import button, clicking adds official registry
- [ ] Existing registries still display normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed the Registry configuration panel's empty-state behavior. The "Import Official Source" button now displays conditionally based on the deployment environment, replacing the previous unconditional rendering. This ensures button visibility is appropriate for different deployment scenarios, improving consistency and providing a more refined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->