### PR TITLE
fix: implement real stats in memstore

### DIFF
--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -183,6 +183,8 @@ func (s *Store) GetAdminStats() (*store.AdminStats, error) {
 	for _, b := range s.bots {
 		if b.Status == "connected" {
 			stats.OnlineBots++
+		} else if b.Status == "session_expired" {
+			stats.ExpiredBots++
 		}
 	}
 	for _, inst := range s.installations {


### PR DESCRIPTION
## Summary

- `GetBotStats` and `GetAdminStats` in memstore now compute actual values from in-memory data instead of returning zero-value structs
- Matches the behavior of SQLite/PostgreSQL implementations

## Test plan

- [ ] Mock server stats endpoints return correct counts for bots, installations, messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)