### PR TITLE
refactor: review center dual-column layout

### DIFF
--- a/web/src/pages/admin-reviews.tsx
+++ b/web/src/pages/admin-reviews.tsx
@@ -175,7 +175,7 @@ export function AdminReviewsPage() {
         {/* Right: Detail Panel */}
         <div className="flex-1 min-w-0">
           {selected ? (
-            <div className="rounded-xl border border-border/50 bg-card p-6 space-y-6 sticky top-24 max-h-[calc(100vh-8rem)] overflow-y-auto">
+            <div className="rounded-xl border border-border/50 bg-card p-6 space-y-6 md:sticky md:top-6 md:max-h-[calc(100vh-10rem)] md:overflow-y-auto">
               {/* Header */}
               <div className="flex items-start gap-4">
                 <AppIcon icon={selected.icon} iconUrl={selected.icon_url} size="h-12 w-12" />


### PR DESCRIPTION
## Summary

Redesign the admin review center from table + Sheet drawer to a dual-column layout:

- **Left column** (320px): scrollable app list sorted by status (pending first), showing icon, name, developer, time, and listing badge. Selected item highlighted.
- **Right column**: sticky detail panel with full app info (developer, version, homepage), description, README, reject reason, and action buttons (approve/reject/toggle listing).
- Pending count badge shown in page header.
- Removed Sheet and Table component dependencies.

## Test plan

- [ ] List shows all apps sorted: pending → listed → unlisted
- [ ] Clicking an app shows its detail in the right panel
- [ ] Approve/reject actions work and refresh the list
- [ ] Toggle listing (上架/下架) works
- [ ] Reject dialog shows and submits correctly
- [ ] Empty state shows "暂无应用" / "选择一个应用查看详情"
- [ ] Selected item stays highlighted after action

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned admin reviews with a responsive two-column layout: left scrollable app list and right sticky detail panel.
  * Added pending-app count badge and deterministic sorting (pending → listed → unlisted, newest first).
  * Expanded detail panel to show core configuration (webhook, tools, events, scopes, optional config schema), description, and review actions; updated empty state illustration.

* **Bug Fixes**
  * Selection now clears when a previously selected app is missing or after a rejection, preventing stale selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->