### PR TITLE
fix: prevent crash on bot detail page due to empty Select value

### DIFF
--- a/web/src/pages/bot-detail.tsx
+++ b/web/src/pages/bot-detail.tsx
@@ -1,6 +1,4 @@
 import { useEffect, useState, useCallback, useRef } from "react";
-
-const DEFAULT_MODEL = DEFAULT_MODEL;
 import { useParams, useNavigate, Link } from "react-router-dom";
 import {
   ArrowUpRight,
@@ -38,6 +36,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { AppIcon } from "../components/app-icon";
 import { parseTools } from "../components/tools-display";
+
+const DEFAULT_MODEL = "__default__";
 
 // ==================== Page ====================
 
@@ -324,7 +324,7 @@ export function BotDetailPage() {
                   <SelectValue placeholder="使用全局默认" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value=DEFAULT_MODEL>使用全局默认</SelectItem>
+                  <SelectItem value={DEFAULT_MODEL}>使用全局默认</SelectItem>
                   {availableModels.filter(Boolean).map((m) => (
                     <SelectItem key={m} value={m}>{m}</SelectItem>
                   ))}


### PR DESCRIPTION
## Summary
- Fix white screen on bot detail page (`/dashboard/accounts/:id`)
- Radix UI `Select.Item` does not allow empty string as `value` prop
- Use sentinel value `"__default__"` for "使用全局默认" option, mapped back to empty string in the handler

## Root Cause
`<SelectItem value="">使用全局默认</SelectItem>` throws:
> A \<Select.Item /> must have a value prop that is not an empty string.

Closes #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the AI model selector so the "use global default" choice is represented consistently and syncs correctly.
  * Prevented empty or invalid model entries from appearing in the model list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->