### PR TITLE
fix: prevent saving masked secrets back to database

### DIFF
--- a/internal/api/config_handler.go
+++ b/internal/api/config_handler.go
@@ -89,10 +89,13 @@ func (s *Server) handleSetOAuthConfig(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "save failed", http.StatusInternalServerError)
 		return
 	}
-	if req.ClientSecret != "" && !strings.Contains(req.ClientSecret, "*") {
-		if err := s.Store.SetConfig("oauth."+name+".client_secret", req.ClientSecret); err != nil {
-			jsonError(w, "save failed", http.StatusInternalServerError)
-			return
+	if req.ClientSecret != "" {
+		current, _ := s.Store.GetConfig("oauth." + name + ".client_secret")
+		if req.ClientSecret != maskSecret(current) {
+			if err := s.Store.SetConfig("oauth."+name+".client_secret", req.ClientSecret); err != nil {
+				jsonError(w, "save failed", http.StatusInternalServerError)
+				return
+			}
 		}
 	}
 	jsonOK(w)
@@ -166,8 +169,11 @@ func (s *Server) handleSetAIConfig(w http.ResponseWriter, r *http.Request) {
 	if req.BaseURL != "" {
 		s.Store.SetConfig("ai.base_url", req.BaseURL)
 	}
-	if req.APIKey != "" && !strings.Contains(req.APIKey, "*") {
-		s.Store.SetConfig("ai.api_key", req.APIKey)
+	if req.APIKey != "" {
+		current, _ := s.Store.GetConfig("ai.api_key")
+		if req.APIKey != maskSecret(current) {
+			s.Store.SetConfig("ai.api_key", req.APIKey)
+		}
 	}
 	if req.Model != "" {
 		s.Store.SetConfig("ai.model", req.Model)


### PR DESCRIPTION
## Summary
- AI API key and OAuth client secret are returned masked (e.g., `sk-t****u9XK`)
- If user saves config without modifying these fields, the masked value was overwriting the real secret
- Now skip saving any secret value containing `*`, indicating it was not changed

## Affected endpoints
- `PUT /api/admin/config/ai` — `api_key` field
- `PUT /api/admin/config/oauth/{provider}` — `client_secret` field

## Test plan
- [ ] Configure AI API key, verify AI works
- [ ] Refresh settings page, save without modifying key, verify AI still works
- [ ] Same test for OAuth client secret

Closes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental overwrites of stored credentials when masked or placeholder secret values are submitted—OAuth client secrets and AI API keys are preserved unless a new secret is provided.
  * Reduces risk of losing configured credentials during credential updates, avoiding unnecessary reconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->