### PR TITLE
feat: show review history in review center

### DIFF
--- a/web/src/pages/admin-reviews.tsx
+++ b/web/src/pages/admin-reviews.tsx
@@ -93,6 +93,7 @@ export function AdminReviewsPage() {
       await api.reviewListing(a.id, true);
       toast({ title: `「${a.name}」已通过上架` });
       loadApps();
+      loadReviews(a.id);
     } catch (e: any) {
       toast({ variant: "destructive", title: "操作失败", description: e.message });
     } finally {
@@ -125,6 +126,7 @@ export function AdminReviewsPage() {
       await api.setAppListing(a.id, newListing);
       toast({ title: newListing === "listed" ? `「${a.name}」已上架` : `「${a.name}」已下架` });
       loadApps();
+      loadReviews(a.id);
     } catch (e: any) {
       toast({ variant: "destructive", title: "操作失败", description: e.message });
     } finally {


### PR DESCRIPTION
## Summary

- Load app review history (`GET /api/apps/{id}/reviews`) when selecting an app in the review center
- Display review timeline with action badges (申请上架/通过/拒绝/撤回), timestamps, versions, and reasons
- Reviews refresh when switching between apps

## Test plan

- [ ] Select an app that has been reviewed — shows review history timeline
- [ ] Select an app with no reviews — no review section shown
- [ ] After approving/rejecting, review history updates on next select

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a review history section to the admin reviews interface, displaying detailed information for each app review including timestamps, action details, version information, and reviewer notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->