### PR TITLE
feat: add copy button to code blocks in guide markdown

### DIFF
--- a/web/src/pages/installation-detail.tsx
+++ b/web/src/pages/installation-detail.tsx
@@ -467,11 +467,16 @@ function TokenSection({ app, inst }: { app: any; inst: any }) {
   useEffect(() => {
     const el = guideRef.current;
     if (!el) return;
+    const timeouts: ReturnType<typeof setTimeout>[] = [];
     el.querySelectorAll("pre").forEach((pre) => {
       if (pre.querySelector(".copy-btn")) return;
+      // Read code text before appending button to avoid including button label
+      const codeText = pre.querySelector("code")?.textContent || pre.textContent || "";
       const btn = document.createElement("button");
+      btn.type = "button";
       btn.className = "copy-btn";
       btn.textContent = "复制";
+      btn.setAttribute("aria-label", "复制代码");
       Object.assign(btn.style, {
         position: "absolute", top: "6px", right: "6px",
         fontSize: "11px", padding: "2px 8px", borderRadius: "4px",
@@ -479,14 +484,17 @@ function TokenSection({ app, inst }: { app: any; inst: any }) {
         color: "var(--muted-foreground)", cursor: "pointer",
       });
       btn.addEventListener("click", () => {
-        const code = pre.querySelector("code")?.textContent || pre.textContent || "";
-        navigator.clipboard.writeText(code).then(() => {
+        navigator.clipboard.writeText(codeText).then(() => {
           btn.textContent = "已复制";
-          setTimeout(() => { btn.textContent = "复制"; }, 2000);
+          timeouts.push(setTimeout(() => { btn.textContent = "复制"; }, 2000));
+        }).catch(() => {
+          btn.textContent = "失败";
+          timeouts.push(setTimeout(() => { btn.textContent = "复制"; }, 2000));
         });
       });
       pre.appendChild(btn);
     });
+    return () => { timeouts.forEach(clearTimeout); };
   }, [guideHtml]);
   const showGenericGuide = !guideText && app.registry === "builtin";
   const showUsageGuide = guideText || showGenericGuide;


### PR DESCRIPTION
## Summary
- Add hover-visible copy button to each `<pre>` code block in the rendered guide markdown
- Uses `navigator.clipboard` API with "已复制" feedback
- Button appears on hover, positioned top-right of the code block
- Uses CSS variables for theme compatibility (dark mode safe)

## Implementation
- `useRef` + `useEffect` to inject buttons after markdown HTML renders
- Depends on `guideHtml` to re-inject when content changes
- Skips blocks that already have a copy button (idempotent)