### PR TITLE
fix: PostgreSQL interval arithmetic operator precedence bug

### DIFF
--- a/internal/store/postgres/app_log.go
+++ b/internal/store/postgres/app_log.go
@@ -103,7 +103,7 @@ func (db *DB) ListAPILogs(installationID string, limit int) ([]store.AppAPILog, 
 
 func (db *DB) CleanOldAppLogs(days int) error {
 	now := db.now()
-	_, _ = db.Exec("DELETE FROM app_event_logs WHERE created_at < $1 - INTERVAL '1 day' * $2", now, days)
-	_, _ = db.Exec("DELETE FROM app_api_logs WHERE created_at < $1 - INTERVAL '1 day' * $2", now, days)
+	_, _ = db.Exec("DELETE FROM app_event_logs WHERE created_at < $1::timestamptz - (INTERVAL '1 day' * $2)", now, days)
+	_, _ = db.Exec("DELETE FROM app_api_logs WHERE created_at < $1::timestamptz - (INTERVAL '1 day' * $2)", now, days)
 	return nil
 }

--- a/internal/store/postgres/bot.go
+++ b/internal/store/postgres/bot.go
@@ -106,7 +106,7 @@ func (db *DB) UpdateBotCredentials(id, providerID string, credentials json.RawMe
 	if err != nil {
 		return err
 	}
-	db.Exec("UPDATE messages SET context_token = '' WHERE bot_id = $1 AND context_token != '' AND created_at > $2 - INTERVAL '1 day'", id, now)
+	db.Exec("UPDATE messages SET context_token = '' WHERE bot_id = $1 AND context_token != '' AND created_at > ($2::timestamptz - INTERVAL '1 day')", id, now)
 	return nil
 }
 
@@ -152,8 +152,8 @@ func (db *DB) GetBotsNeedingReminder() ([]store.Bot, error) {
 		WHERE status = 'connected'
 		AND reminder_hours > 0
 		AND last_msg_at IS NOT NULL
-		AND last_msg_at < $1 - INTERVAL '1 hour' * reminder_hours
-		AND (last_reminded_at IS NULL OR last_reminded_at < $1 - INTERVAL '1 hour')`, now)
+		AND last_msg_at < ($1::timestamptz - INTERVAL '1 hour' * reminder_hours)
+		AND (last_reminded_at IS NULL OR last_reminded_at < ($1::timestamptz - INTERVAL '1 hour'))`, now)
 	if err != nil {
 		return nil, err
 	}
@@ -267,10 +267,8 @@ func (db *DB) BatchHasFreshContextToken(botIDs []string, maxAge time.Duration) m
 		args = append(args, id)
 	}
 
-	rows, err := db.Query(
-		"SELECT DISTINCT bot_id FROM messages WHERE bot_id IN ("+strings.Join(placeholders, ",")+") AND context_token != '' AND created_at > $1 - $2 * INTERVAL '1 second'",
-		args...,
-	)
+	query := "SELECT DISTINCT bot_id FROM messages WHERE bot_id IN (" + strings.Join(placeholders, ",") + ") AND context_token != '' AND created_at > $1::timestamptz - ($2 * INTERVAL '1 second')"
+	rows, err := db.Query(query, args...)
 	if err != nil {
 		return result
 	}

--- a/internal/store/postgres/message.go
+++ b/internal/store/postgres/message.go
@@ -132,7 +132,7 @@ func (db *DB) GetLatestContextToken(botID string) string {
 func (db *DB) HasFreshContextToken(botID string, maxAge time.Duration) bool {
 	var exists bool
 	db.QueryRow(
-		"SELECT EXISTS(SELECT 1 FROM messages WHERE bot_id = $1 AND context_token != '' AND created_at > $2 - $3 * INTERVAL '1 second')",
+		"SELECT EXISTS(SELECT 1 FROM messages WHERE bot_id = $1 AND context_token != '' AND created_at > $2::timestamptz - ($3 * INTERVAL '1 second'))",
 		botID, db.now(), int(maxAge.Seconds()),
 	).Scan(&exists)
 	return exists
@@ -185,7 +185,7 @@ func (db *DB) UpdateMediaPayloads(botID, eqp string, newPayload json.RawMessage)
 }
 
 func (db *DB) MarkProcessed(id int64) error {
-	_, err := db.Exec("UPDATE messages SET processed_at = $1 WHERE id = $2", db.now(), id)
+	_, err := db.Exec("UPDATE messages SET processed_at = $1::timestamptz WHERE id = $2", db.now(), id)
 	return err
 }
 
@@ -194,13 +194,13 @@ func (db *DB) GetUnprocessedMessages(botID string, limit int) ([]store.Message, 
 		limit = 100
 	}
 	return scanMessages(db,
-		"SELECT "+msgSelectCols+" FROM messages WHERE bot_id = $1 AND direction = 'inbound' AND processed_at IS NULL AND created_at > $2 - INTERVAL '1 day' ORDER BY id ASC LIMIT $3",
+		"SELECT "+msgSelectCols+" FROM messages WHERE bot_id = $1 AND direction = 'inbound' AND processed_at IS NULL AND created_at > ($2::timestamptz - INTERVAL '1 day') ORDER BY id ASC LIMIT $3",
 		botID, db.now(), limit,
 	)
 }
 
 func (db *DB) PruneMessages(maxAgeDays int) (int64, error) {
-	result, err := db.Exec("DELETE FROM messages WHERE created_at < $1 - INTERVAL '1 day' * $2", db.now(), maxAgeDays)
+	result, err := db.Exec("DELETE FROM messages WHERE created_at < $1::timestamptz - (INTERVAL '1 day' * $2)", db.now(), maxAgeDays)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/store/postgres/webhook_log.go
+++ b/internal/store/postgres/webhook_log.go
@@ -78,6 +78,6 @@ func (db *DB) ListWebhookLogs(botID, channelID string, limit int) ([]store.Webho
 }
 
 func (db *DB) CleanOldWebhookLogs(days int) error {
-	_, err := db.Exec("DELETE FROM webhook_logs WHERE created_at < $1 - INTERVAL '1 day' * $2", db.now(), days)
+	_, err := db.Exec("DELETE FROM webhook_logs WHERE created_at < $1::timestamptz - (INTERVAL '1 day' * $2)", db.now(), days)
 	return err
 }


### PR DESCRIPTION
## Summary

PostgreSQL queries with `$1 - $2 * INTERVAL '1 second'` fail with:
```
ERROR: operator does not exist: timestamp with time zone > interval (SQLSTATE 42883)
```

Because PG evaluates `$1 - $2` first (timestamp - int = type error) instead of `$1 - ($2 * interval)`.

**Root cause**: commit 66d0a06 replaced `NOW()` with parameterized `db.now()`. When `NOW()` was used inline, PG could infer types correctly. With parameterized `$1` (timestamptz) and `$2` (int), the operator precedence breaks.

**Fix**: Add explicit parentheses around all `$N * INTERVAL` expressions.

**Affected queries** (all in `internal/store/postgres/`):
- `HasFreshContextToken` (message.go)
- `BatchHasFreshContextToken` (bot.go)
- `PruneMessages` (message.go)
- `CleanOldWebhookLogs` (webhook_log.go)
- `CleanOldAppLogs` (app_log.go)

Fixes #119

## Test plan

- [ ] Bot list page shows `can_send: true` for bots with recent messages
- [ ] "暂无法发送：需要先收到用户消息" error no longer appears incorrectly
- [ ] `GetUnprocessedMessages` no longer errors on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected interval-based timestamp comparisons used in background cleanup and pruning, ensuring expired records are removed reliably.
  * Improved accuracy of message pruning, log cleanup, and context-token freshness checks for more consistent data retention and system stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->