### PR TITLE
refactor: decouple OIDC routes from OAuth namespace

### DIFF
--- a/internal/api/oauth_handler.go
+++ b/internal/api/oauth_handler.go
@@ -136,7 +136,8 @@ func (s *Server) handleOAuthProviders(w http.ResponseWriter, r *http.Request) {
 	type providerInfo struct {
 		Name        string `json:"name"`
 		DisplayName string `json:"display_name"`
-		Type        string `json:"type"` // "oauth" or "oidc"
+		Type        string `json:"type"`         // "oauth" or "oidc"
+		Key         string `json:"key,omitempty"` // internal key for account matching (omitted when same as name)
 	}
 
 	var list []providerInfo
@@ -152,9 +153,10 @@ func (s *Server) handleOAuthProviders(w http.ResponseWriter, r *http.Request) {
 	// Custom OIDC providers
 	for slug, cfg := range s.oidcProviders() {
 		list = append(list, providerInfo{
-			Name:        "oidc_" + slug,
+			Name:        slug,
 			DisplayName: cfg.DisplayName,
 			Type:        "oidc",
+			Key:         oidcProviderKey(slug),
 		})
 	}
 
@@ -170,10 +172,6 @@ func (s *Server) handleOAuthRedirect(w http.ResponseWriter, r *http.Request) {
 	providers := s.oauthProviders()
 	p, ok := providers[name]
 	if !ok {
-		if strings.HasPrefix(name, "oidc_") {
-			s.handleOIDCRedirect(w, r, strings.TrimPrefix(name, "oidc_"), "")
-			return
-		}
 		jsonError(w, "unknown provider", http.StatusBadRequest)
 		return
 	}
@@ -199,10 +197,6 @@ func (s *Server) handleOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	providers := s.oauthProviders()
 	p, ok := providers[name]
 	if !ok {
-		if strings.HasPrefix(name, "oidc_") {
-			s.handleOIDCCallback(w, r, name, strings.TrimPrefix(name, "oidc_"))
-			return
-		}
 		jsonError(w, "unknown provider", http.StatusBadRequest)
 		return
 	}
@@ -303,10 +297,6 @@ func (s *Server) handleOAuthBind(w http.ResponseWriter, r *http.Request) {
 	providers := s.oauthProviders()
 	p, ok := providers[name]
 	if !ok {
-		if strings.HasPrefix(name, "oidc_") {
-			s.handleOIDCRedirect(w, r, strings.TrimPrefix(name, "oidc_"), userID)
-			return
-		}
 		jsonError(w, "unknown provider", http.StatusBadRequest)
 		return
 	}
@@ -401,7 +391,7 @@ func (s *Server) findOrCreateOAuthUser(provider, providerID, username, email, av
 	// OIDC providers are not trusted for email auto-linking because the email
 	// claim may be unverified, enabling account takeover.
 	var user *store.User
-	if email != "" && !strings.HasPrefix(provider, "oidc_") {
+	if email != "" && !strings.HasPrefix(provider, "oidc:") {
 		user, err = s.Store.GetUserByEmail(email)
 		if err != nil && err != sql.ErrNoRows {
 			return nil, err

--- a/internal/api/oidc_handler.go
+++ b/internal/api/oidc_handler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/openilink/openilink-hub/internal/auth"
 	"golang.org/x/oauth2"
 )
 
@@ -180,9 +181,32 @@ func (s *Server) oidcExchangeAndIdentify(ctx context.Context, cfg *OIDCProviderC
 	return "", "", "", "", fmt.Errorf("no id_token or userinfo_endpoint available")
 }
 
-// --- OIDC redirect / callback helpers (called from oauth_handler.go) ---
+// --- OIDC redirect / callback handlers (independent routes) ---
 
-func (s *Server) handleOIDCRedirect(w http.ResponseWriter, r *http.Request, slug, bindUID string) {
+// oidcRedirectURI builds the callback URL for the given slug.
+func (s *Server) oidcRedirectURI(slug string) string {
+	return s.Config.RPOrigin + "/api/auth/oidc/" + slug + "/callback"
+}
+
+// oidcProviderKey returns the internal provider key for storing in oauth_accounts.
+func oidcProviderKey(slug string) string {
+	return "oidc:" + slug
+}
+
+// GET /api/auth/oidc/{slug} — redirect to OIDC provider (login flow)
+func (s *Server) handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	s.oidcRedirectToProvider(w, r, slug, "")
+}
+
+// GET /api/me/oidc/{slug}/bind — redirect to OIDC provider (bind flow, protected)
+func (s *Server) handleOIDCBind(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	userID := auth.UserIDFromContext(r.Context())
+	s.oidcRedirectToProvider(w, r, slug, userID)
+}
+
+func (s *Server) oidcRedirectToProvider(w http.ResponseWriter, r *http.Request, slug, bindUID string) {
 	providers := s.oidcProviders()
 	cfg, ok := providers[slug]
 	if !ok {
@@ -191,11 +215,10 @@ func (s *Server) handleOIDCRedirect(w http.ResponseWriter, r *http.Request, slug
 	}
 
 	state := s.OAuthStates.Generate(bindUID)
-	providerName := "oidc_" + slug
 
 	params := url.Values{
 		"client_id":     {cfg.ClientID},
-		"redirect_uri":  {s.Config.RPOrigin + "/api/auth/oauth/" + providerName + "/callback"},
+		"redirect_uri":  {s.oidcRedirectURI(slug)},
 		"state":         {state},
 		"response_type": {"code"},
 	}
@@ -219,7 +242,9 @@ func (s *Server) handleOIDCRedirect(w http.ResponseWriter, r *http.Request, slug
 	http.Redirect(w, r, cfg.AuthURL+"?"+params.Encode(), http.StatusFound)
 }
 
-func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request, providerName, slug string) {
+// GET /api/auth/oidc/{slug}/callback — handle OIDC callback
+func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
 	providers := s.oidcProviders()
 	cfg, ok := providers[slug]
 	if !ok {
@@ -237,7 +262,7 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request, prov
 	// Handle provider-returned OAuth errors (e.g. access_denied)
 	if oauthErr := r.URL.Query().Get("error"); oauthErr != "" {
 		desc := r.URL.Query().Get("error_description")
-		slog.Warn("oidc provider returned error", "provider", providerName, "error", oauthErr, "description", desc)
+		slog.Warn("oidc provider returned error", "slug", slug, "error", oauthErr, "description", desc)
 		http.Redirect(w, r, "/login?error=oauth_"+oauthErr, http.StatusFound)
 		return
 	}
@@ -248,17 +273,18 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request, prov
 		return
 	}
 
-	redirectURI := s.Config.RPOrigin + "/api/auth/oauth/" + providerName + "/callback"
+	providerKey := oidcProviderKey(slug)
+	redirectURI := s.oidcRedirectURI(slug)
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 	providerID, username, email, avatarURL, err := s.oidcExchangeAndIdentify(ctx, cfg, redirectURI, code)
 	if err != nil {
-		slog.Error("oidc exchange failed", "provider", providerName, "err", err)
+		slog.Error("oidc exchange failed", "slug", slug, "err", err)
 		jsonError(w, "OIDC login failed", http.StatusBadGateway)
 		return
 	}
 
-	s.completeOAuthFlow(w, r, entry, providerName, providerID, username, email, avatarURL)
+	s.completeOAuthFlow(w, r, entry, providerKey, providerID, username, email, avatarURL)
 }
 
 // --- Admin CRUD handlers ---

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -62,6 +62,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/auth/oauth/{provider}", s.handleOAuthRedirect)
 	mux.HandleFunc("GET /api/auth/oauth/{provider}/callback", s.handleOAuthCallback)
 
+	// --- OIDC (independent routes for custom identity providers) ---
+	mux.HandleFunc("GET /api/auth/oidc/{slug}", s.handleOIDCLogin)
+	mux.HandleFunc("GET /api/auth/oidc/{slug}/callback", s.handleOIDCCallback)
+
 	// --- iLink scan login: scan QR to register + login + bind bot ---
 	mux.HandleFunc("POST /api/auth/scan/start", s.handleScanLoginStart)
 	mux.HandleFunc("GET /api/auth/scan/status/{sessionID}", s.handleScanLoginStatus)
@@ -115,6 +119,7 @@ func (s *Server) Handler() http.Handler {
 	protected.HandleFunc("GET /api/me/linked-accounts", s.handleOAuthAccounts)
 	protected.HandleFunc("GET /api/me/linked-accounts/{provider}/bind", s.handleOAuthBind)
 	protected.HandleFunc("DELETE /api/me/linked-accounts/{provider}", s.handleOAuthUnbind)
+	protected.HandleFunc("GET /api/me/oidc/{slug}/bind", s.handleOIDCBind)
 
 	// Bots
 	protected.HandleFunc("GET /api/bots", s.handleListBots)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -55,7 +55,7 @@ export const api = {
     request<{ providers: any[] }>("/api/auth/oauth/providers").then((data) => ({
       providers: (data.providers || []).map((p: any) =>
         typeof p === "string" ? { name: p, display_name: p, type: "oauth" } : p
-      ) as Array<{ name: string; display_name: string; type: string }>,
+      ) as Array<{ name: string; display_name: string; type: string; key?: string }>,
     })),
   me: () =>
     request<{ id: string; username: string; display_name: string; role: string }>("/api/me"),

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -52,7 +52,7 @@ export function LoginPage() {
   const [showPassword, setShowPassword] = useState(false);
 
   // OAuth
-  const [oauthProviders, setOauthProviders] = useState<Array<{ name: string; display_name: string; type: string }>>([]);
+  const [oauthProviders, setOauthProviders] = useState<Array<{ name: string; display_name: string; type: string; key?: string }>>([]);
 
   // Registration enabled flag (from /api/info)
   const [registrationEnabled, setRegistrationEnabled] = useState(true);
@@ -288,7 +288,7 @@ export function LoginPage() {
                       key={provider.name}
                       variant="outline"
                       className="w-full h-9 gap-2 font-medium text-sm"
-                      onClick={() => (window.location.href = `/api/auth/oauth/${provider.name}`)}
+                      onClick={() => (window.location.href = provider.type === "oidc" ? `/api/auth/oidc/${provider.name}` : `/api/auth/oauth/${provider.name}`)}
                     >
                       <config.icon className="h-4 w-4" />
                       使用 {config.label} 登录

--- a/web/src/pages/settings.tsx
+++ b/web/src/pages/settings.tsx
@@ -42,7 +42,7 @@ export function SettingsPage() {
   const location = useLocation();
   const [user, setUser] = useState<any>(null);
   const [oauthAccounts, setOauthAccounts] = useState<any[]>([]);
-  const [oauthProviders, setOauthProviders] = useState<Array<{ name: string; display_name: string; type: string }>>([]);
+  const [oauthProviders, setOauthProviders] = useState<Array<{ name: string; display_name: string; type: string; key?: string }>>([]);
   const [loading, setLoading] = useState(true);
   const { theme, setTheme } = useTheme();
   const { confirm, ConfirmDialog } = useConfirm();
@@ -154,7 +154,8 @@ export function SettingsPage() {
               </CardHeader>
               <CardContent className="space-y-3">
                 {oauthProviders.map((provider) => {
-                  const account = oauthAccounts.find((a) => a.provider === provider.name);
+                  const providerKey = provider.key || provider.name;
+                  const account = oauthAccounts.find((a) => a.provider === providerKey);
                   const linked = !!account;
                   const Icon = providerLabels[provider.name]?.icon || ShieldCheck;
                   const label = providerLabels[provider.name]?.label || provider.display_name || provider.name;
@@ -191,7 +192,7 @@ export function SettingsPage() {
                             });
                             if (!ok) return;
                             try {
-                              await api.unlinkOAuth(provider.name);
+                              await api.unlinkOAuth(providerKey);
                               load();
                             } catch (e: any) {
                               setOauthMsg(e.message);
@@ -205,7 +206,7 @@ export function SettingsPage() {
                           variant="outline"
                           size="sm"
                           onClick={() =>
-                            (window.location.href = `/api/me/linked-accounts/${provider.name}/bind`)
+                            (window.location.href = provider.type === "oidc" ? `/api/me/oidc/${provider.name}/bind` : `/api/me/linked-accounts/${provider.name}/bind`)
                           }
                         >
                           <Link2 className="h-3.5 w-3.5 mr-2" /> 绑定


### PR DESCRIPTION
## Summary
- OIDC 提供商从 `/api/auth/oauth/oidc_{slug}/...` 迁移到独立路由 `/api/auth/oidc/{slug}/...`
- 删除 `oauth_handler.go` 中所有 `oidc_` 前缀判断逻辑，两个协议完全解耦
- 内部 provider key 从 `oidc_slug` 改为 `oidc:slug`，providers API 新增 `key` 字段用于前端匹配账号

## 路由变更

| 用途 | 旧路径 | 新路径 |
|------|--------|--------|
| 登录 | `/api/auth/oauth/oidc_{slug}` | `/api/auth/oidc/{slug}` |
| 回调 | `/api/auth/oauth/oidc_{slug}/callback` | `/api/auth/oidc/{slug}/callback` |
| 绑定 | `/api/me/linked-accounts/oidc_{slug}/bind` | `/api/me/oidc/{slug}/bind` |

## 部署注意事项
- **Redirect URI 需更新**：已配置的 OIDC 提供商需在 IdP 侧将 Redirect URI 从 `{origin}/api/auth/oauth/oidc_{slug}/callback` 改为 `{origin}/api/auth/oidc/{slug}/callback`
- 由于 OIDC 功能刚合并（#142），尚无生产用户，影响范围为零
- 无数据库迁移

## Test plan
- [ ] OIDC 登录跳转到 `/api/auth/oidc/{slug}`，回调到正确路径
- [ ] 设置页绑定/解绑 OIDC 账号正常
- [ ] GitHub/LinuxDo 登录不受影响
- [ ] providers API 返回的 OIDC provider 包含 `key` 字段

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OIDC provider authentication routing for improved reliability and error handling.
  * Refined email-based account lookup logic for OIDC providers.

* **New Features**
  * Improved OIDC provider metadata with key field support for better account linking identification.
  * Separated and streamlined login and account binding flows for OIDC providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->