### PR TITLE
refactor: migrate Admin pages to react-query (Phase 4)

### DIFF
--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -71,13 +71,7 @@ export function useRegistryConfig() {
 export function useRegistrationConfig() {
   return useQuery({
     queryKey: queryKeys.admin.registrationConfig(),
-    queryFn: async () => {
-      try {
-        return await api.getRegistrationConfig();
-      } catch {
-        return { enabled: "true" };
-      }
-    },
+    queryFn: () => api.getRegistrationConfig(),
     staleTime: 60_000,
   });
 }
@@ -123,7 +117,10 @@ export function useReviewListing() {
   return useMutation({
     mutationFn: ({ appId, approve, reason }: { appId: string; approve: boolean; reason?: string }) =>
       api.reviewListing(appId, approve, reason),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.admin.apps() }),
+    onSuccess: (_data, { appId }) => {
+      qc.invalidateQueries({ queryKey: queryKeys.admin.apps() });
+      qc.invalidateQueries({ queryKey: queryKeys.apps.reviews(appId) });
+    },
   });
 }
 

--- a/web/src/pages/admin-apps.tsx
+++ b/web/src/pages/admin-apps.tsx
@@ -6,6 +6,8 @@ import { Dialog, DialogContent } from "../components/ui/dialog";
 import { api } from "../lib/api";
 import { Blocks, Trash2, X, Pencil } from "lucide-react";
 import { useConfirm, usePrompt } from "@/components/ui/confirm-dialog";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/query-keys";
 import {
   useAdminApps,
   useSetAppListing,
@@ -14,6 +16,7 @@ import {
 } from "@/hooks/use-admin";
 
 export function AdminAppsTab() {
+  const queryClient = useQueryClient();
   const { data: apps = [] } = useAdminApps();
   const [selected, setSelected] = useState<any>(null);
   const [editing, setEditing] = useState(false);
@@ -177,6 +180,7 @@ export function AdminAppsTab() {
                 onSave={() => {
                   setEditing(false);
                   setSelected(null);
+                  queryClient.invalidateQueries({ queryKey: queryKeys.admin.apps() });
                 }}
                 onCancel={() => setEditing(false)}
               />
@@ -186,11 +190,14 @@ export function AdminAppsTab() {
                 onEdit={() => setEditing(true)}
                 onDelete={() => handleDelete(selected)}
                 onClose={() => setSelected(null)}
-                onToggleListing={() => {
+                onToggleListing={async () => {
                   const newListing = selected.listing === "listed" ? "unlisted" : "listed";
-                  setListingMutation.mutateAsync({ id: selected.id, listing: newListing }).then(() => {
+                  try {
+                    await setListingMutation.mutateAsync({ id: selected.id, listing: newListing });
                     setSelected({ ...selected, listing: newListing });
-                  });
+                  } catch {
+                    // mutation error handled by react-query
+                  }
                 }}
               />
             )

--- a/web/src/pages/admin-overview.tsx
+++ b/web/src/pages/admin-overview.tsx
@@ -102,6 +102,7 @@ export function AdminOverviewPage() {
   }, [effectiveAIConfig?.available_models]);
 
   async function handleSaveAI() {
+    if (!effectiveAIConfig) return;
     try {
       await saveAIMutation.mutateAsync(effectiveAIConfig);
       toast({ title: "全局 AI 配置已保存" });

--- a/web/src/pages/admin-reviews.tsx
+++ b/web/src/pages/admin-reviews.tsx
@@ -63,7 +63,8 @@ const TABS: { key: TabFilter; label: string }[] = [
 
 export function AdminReviewsPage() {
   const { data: apps = [], isLoading: loading } = useAdminApps();
-  const [selected, setSelected] = useState<any>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = selectedId ? apps.find((a: any) => a.id === selectedId) ?? null : null;
   const [rejectTarget, setRejectTarget] = useState<any>(null);
   const [rejectReason, setRejectReason] = useState("");
   const [tab, setTab] = useState<TabFilter>("pending");
@@ -93,7 +94,7 @@ export function AdminReviewsPage() {
       toast({ title: `「${rejectTarget.name}」已拒绝` });
       setRejectTarget(null);
       setRejectReason("");
-      setSelected(null);
+      setSelectedId(null);
     } catch (e: any) {
       toast({ variant: "destructive", title: "操作失败", description: e.message });
     }
@@ -151,7 +152,7 @@ export function AdminReviewsPage() {
           if (next >= 0) {
             e.preventDefault();
             setTab(keys[next]);
-            setSelected(null);
+            setSelectedId(null);
             tabListRef.current?.querySelectorAll<HTMLButtonElement>("[role=tab]")[next]?.focus();
           }
         }}
@@ -164,7 +165,7 @@ export function AdminReviewsPage() {
             aria-selected={tab === key}
             aria-controls="review-tabpanel"
             tabIndex={tab === key ? 0 : -1}
-            onClick={() => { setTab(key); setSelected(null); }}
+            onClick={() => { setTab(key); setSelectedId(null); }}
             className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-sm font-medium transition-all ${
               tab === key
                 ? "bg-background text-foreground shadow-sm"
@@ -210,7 +211,7 @@ export function AdminReviewsPage() {
             sorted.map((a: any) => (
               <button
                 key={a.id}
-                onClick={() => setSelected(a)}
+                onClick={() => setSelectedId(a.id)}
                 aria-current={selected?.id === a.id ? "true" : undefined}
                 className={`w-full flex items-center gap-3 p-3 rounded-lg text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
                   selected?.id === a.id

--- a/web/src/pages/admin-users.tsx
+++ b/web/src/pages/admin-users.tsx
@@ -27,8 +27,12 @@ export function AdminUsersPage() {
   const { confirm, ConfirmDialog } = useConfirm();
 
   async function handleUpdateStatus(id: string, status: string) {
-    await updateStatusMutation.mutateAsync({ id, status });
-    toast({ title: "状态已更新" });
+    try {
+      await updateStatusMutation.mutateAsync({ id, status });
+      toast({ title: "状态已更新" });
+    } catch (e: any) {
+      toast({ variant: "destructive", title: "操作失败", description: e.message });
+    }
   }
 
   return (
@@ -113,7 +117,12 @@ export function AdminUsersPage() {
                                 variant: "destructive",
                               });
                               if (ok) {
-                                await deleteUserMutation.mutateAsync(u.id);
+                                try {
+                                  await deleteUserMutation.mutateAsync(u.id);
+                                  toast({ title: "已删除用户" });
+                                } catch (e: any) {
+                                  toast({ variant: "destructive", title: "删除失败", description: e.message });
+                                }
                               }
                             }}
                           >


### PR DESCRIPTION
## Summary
迁移 4 个 Admin 页面到 react-query，新增 `use-admin.ts` hooks 文件。

### 新增 hooks (use-admin.ts)
- **Query**: useAdminStats, useAdminUsers, useAdminApps, useAIConfig, useOAuthConfig, useOIDCConfig, useRegistries, useRegistryConfig, useRegistrationConfig, useAppReviewHistory
- **Mutation**: useUpdateUserStatus, useDeleteUser, useSetAppListing, useReviewListing, useSaveAIConfig, useSetRegistrationConfig, useSetRegistryConfig, useCreateRegistry, useUpdateRegistry, useDeleteRegistry, useSetOIDCConfig, useDeleteOIDCConfig

### 迁移页面
| 页面 | 改动 |
|------|------|
| admin-overview.tsx | stats/AI config/registration/registry/OIDC config 全部走 hooks |
| admin-users.tsx | useAdminUsers + mutation hooks |
| admin-apps.tsx | useAdminApps + listing/review mutations |
| admin-reviews.tsx | useAdminApps + useAppReviewHistory + review mutations |

## Test plan
- [ ] 系统概览：统计、AI 配置、注册开关、Registry、OIDC 配置
- [ ] 用户管理：列表、状态变更、删除
- [ ] 应用管理：列表、上下架、编辑
- [ ] 审核中心：审核列表、通过/拒绝、审核历史

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined admin panel data flows so dashboards, users, apps, reviews, and config pages load and sync more reliably with fewer full-page reloads.
* **New Features**
  * Optimistic updates and clearer disabled states during saves/operations for a snappier, more responsive admin experience.
* **Bug Fixes**
  * Reduced UI refresh glitches after mutations; review history and listings now update consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->