### PR TITLE
fix: include ai_model in bot list API response

### DIFF
--- a/internal/api/bot_handler.go
+++ b/internal/api/bot_handler.go
@@ -34,6 +34,7 @@ func (s *Server) handleListBots(w http.ResponseWriter, r *http.Request) {
 		CanSend            bool            `json:"can_send"`
 		SendDisabledReason string          `json:"send_disabled_reason,omitempty"`
 		AIEnabled          bool            `json:"ai_enabled"`
+		AIModel            string          `json:"ai_model"`
 		MsgCount           int64           `json:"msg_count"`
 		ReminderHours      int             `json:"reminder_hours"`
 		LastMsgAt          *int64          `json:"last_msg_at,omitempty"`
@@ -59,7 +60,7 @@ func (s *Server) handleListBots(w http.ResponseWriter, r *http.Request) {
 		result = append(result, botResp{
 			ID: b.ID, Name: b.Name, DisplayName: b.DisplayName, Provider: b.Provider,
 			Status: status, CanSend: canSend, SendDisabledReason: reason,
-			AIEnabled: b.AIEnabled,
+			AIEnabled: b.AIEnabled, AIModel: b.AIModel,
 			MsgCount: b.MsgCount, ReminderHours: b.ReminderHours,
 			LastMsgAt: b.LastMsgAt, LastRemindedAt: b.LastRemindedAt,
 			CreatedAt: b.CreatedAt, Extra: extra,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -7,6 +7,7 @@ export interface Bot {
   can_send: boolean;
   send_disabled_reason?: string;
   ai_enabled: boolean;
+  ai_model: string;
   msg_count: number;
   reminder_hours: number;
   last_msg_at?: number;


### PR DESCRIPTION
## Summary
- Add missing `ai_model` field to `botResp` struct in `handleListBots`, so the list API returns the per-account model
- Add missing `ai_model` field to frontend `Bot` TypeScript interface

Closes #152

## Test plan
- [ ] Change an account's model to something other than global default
- [ ] Refresh the page — the selected model should now display correctly instead of "使用全局默认"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bot information now includes the AI model being used. Users can view the specific AI model assigned to each bot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->