### PR TITLE
fix: differentiate registry toggle labels to avoid confusion

### DIFF
--- a/web/src/pages/admin-overview.tsx
+++ b/web/src/pages/admin-overview.tsx
@@ -402,6 +402,7 @@ function RegistryConfigCard() {
             <p className="text-xs text-muted-foreground">允许其他 Hub 从此实例拉取应用</p>
           </div>
           <Switch
+            aria-label="对外暴露 Registry"
             checked={registryConfig?.enabled === "true"}
             onCheckedChange={handleToggleExpose}
             disabled={setRegistryConfigMutation.isPending}
@@ -434,8 +435,10 @@ function RegistryConfigCard() {
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
                   <Switch
+                    aria-label={`启用 ${reg.name}`}
                     checked={reg.enabled}
                     onCheckedChange={() => handleToggleRegistry(reg)}
+                    disabled={updateRegistryMutation.isPending}
                   />
                   <Tooltip>
                     <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- Change "对外暴露 Registry" control from Button to Switch component, vis觉上明确是开关
- Rename per-source registry toggle labels from "启用/禁用" to "已开启/已关闭"，和上面的 Switch 在形态和文字上完全区分
- Addresses user feedback in #154 about two "禁用" labels causing confusion

## Test plan
- [ ] Verify "对外暴露 Registry" now shows as a Switch toggle
- [ ] Verify per-source registry buttons show "已开启"/"已关闭"
- [ ] Toggle both controls and confirm they work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Replaced the registry configuration control with a toggle switch for clearer on/off state and direct interaction.
  * Replaced per-registry enable/disable buttons with individual switches to make status changes faster and more discoverable.
  * Controls are temporarily disabled while changes are being saved to prevent duplicate actions and provide clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->