### PR TITLE
feat: support editing OIDC providers and display callback URL

### DIFF
--- a/web/src/pages/admin-overview.tsx
+++ b/web/src/pages/admin-overview.tsx
@@ -721,7 +721,7 @@ function OIDCConfigCard() {
             onClick={handleSave}
             disabled={saving || !slug.trim() || !issuerUrl.trim() || !clientId.trim()}
           >
-            {saving ? <Loader2 className="w-3.5 h-3.5 mr-1 animate-spin" /> : <Plus className="w-3.5 h-3.5 mr-1" />}
+            {saving ? <Loader2 className="w-3.5 h-3.5 mr-1 animate-spin" /> : isEditing ? <Check className="w-3.5 h-3.5 mr-1" /> : <Plus className="w-3.5 h-3.5 mr-1" />}
             {isEditing ? "保存" : "添加"}
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- Add edit button to each OIDC provider, populating the form with existing config (slug and issuer_url locked in edit mode per backend constraint)
- Display callback URL (`/api/auth/oidc/{slug}/callback`) with one-click copy for each provider
- Edit mode: client secret placeholder shows "留空保持不变", backend auto-preserves existing secret when empty

Closes #156

## Test plan
- [ ] Add a new OIDC provider, verify it appears with callback URL
- [ ] Click edit, modify display_name / client_id / scopes, save — verify update works
- [ ] Verify slug and issuer_url are disabled (not editable) in edit mode
- [ ] Leave client secret empty on edit — verify existing secret is preserved
- [ ] Copy callback URL — verify clipboard content is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OIDC configuration form now supports editing existing providers alongside adding new ones.
  * Callback addresses are displayed per provider with one-click copy functionality.
  * Action buttons (edit/delete) added to provider list for easier management.
  * Improved form messaging to better reflect operation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->