### PR TITLE
fix: validate registry URL after normalization

### DIFF
--- a/internal/api/registry_admin_handler.go
+++ b/internal/api/registry_admin_handler.go
@@ -51,6 +51,14 @@ func (s *Server) handleCreateRegistry(w http.ResponseWriter, r *http.Request) {
 	parsed.Path = strings.TrimSuffix(strings.TrimRight(parsed.Path, "/"), "/api/registry/v1/apps.json")
 	u := strings.TrimRight(parsed.String(), "/")
 
+	// Re-validate after normalization to catch URLs that become invalid
+	// after stripping query params, fragments, and well-known path suffix.
+	normalized, err := url.Parse(u)
+	if err != nil || normalized.Host == "" || (normalized.Scheme != "http" && normalized.Scheme != "https") {
+		jsonError(w, "invalid url after normalization", http.StatusBadRequest)
+		return
+	}
+
 	reg := &store.Registry{
 		Name:    req.Name,
 		URL:     u,


### PR DESCRIPTION
## Summary
- Add URL validation after normalization in registry create handler
- Prevents invalid URLs from being saved to the database
- Avoids downstream 502 errors when marketplace fetches from invalid registry URLs

Fixes #165

## Test plan
- [ ] Test adding a registry with a valid URL
- [ ] Test adding a registry with an invalid URL (should return 400)
- [ ] Verify marketplace endpoint works after adding a valid registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL validation when creating registries to prevent invalid configurations from being stored. The system now properly validates registry URLs after normalization and rejects invalid entries with informative error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->