### PR TITLE
fix: remove broken traces quick link from dashboard overview

### DIFF
--- a/web/src/pages/dashboard-overview.tsx
+++ b/web/src/pages/dashboard-overview.tsx
@@ -50,7 +50,6 @@ const STEPS = [
 const QUICK_LINKS = [
   { label: "全部账号", icon: Bot, link: "/dashboard/accounts" },
   { label: "应用市场", icon: Workflow, link: "/dashboard/apps" },
-  { label: "消息追踪", icon: MessageSquare, link: "/dashboard/traces" },
   { label: "系统设置", icon: Cpu, link: "/dashboard/settings/profile" },
 ] as const;
 


### PR DESCRIPTION
## Summary
- Remove the "消息追踪" quick link from dashboard overview that pointed to non-existent `/dashboard/traces` route
- Traces are accessed per-bot from each bot's detail page, not globally

Fixes #166

## Test plan
- [ ] Verify dashboard overview no longer shows broken traces link
- [ ] Verify per-bot traces still work from bot detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the "Message Tracking" quick link from the dashboard overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->