### PR TITLE
fix: admin user delete button not responding

### DIFF
--- a/web/src/pages/admin-users.tsx
+++ b/web/src/pages/admin-users.tsx
@@ -109,8 +109,8 @@ export function AdminUsersPage() {
                           </DropdownMenuItem>
                           <DropdownMenuItem
                             className="text-destructive focus:bg-destructive/10 focus:text-destructive"
-                            onSelect={(e) => e.preventDefault()}
-                            onClick={async () => {
+                            onSelect={async (e) => {
+                              e.preventDefault();
                               const ok = await confirm({
                                 title: "删除确认",
                                 description: "确定要删除此用户？",

--- a/web/src/pages/bots.tsx
+++ b/web/src/pages/bots.tsx
@@ -274,8 +274,10 @@ function BotInstanceCard({
                 </DropdownMenuItem>
               ) : null}
               <DropdownMenuItem
-                onSelect={(e) => e.preventDefault()}
-                onClick={() => handleAction("delete")}
+                onSelect={(e) => {
+                  e.preventDefault();
+                  void handleAction("delete");
+                }}
                 className="gap-2 text-destructive focus:bg-destructive/10 focus:text-destructive"
               >
                 <Trash2 className="h-3.5 w-3.5" /> 删除账号


### PR DESCRIPTION
## Summary
- Fixes #170: 账号管理页面删除按钮点击无反应
- Root cause: Radix UI `DropdownMenuItem` auto-closes the menu on click, which interferes with `AlertDialog` focus management, preventing the confirmation dialog from opening
- Fix: add `onSelect={(e) => e.preventDefault()}` to stop the menu from auto-closing before the dialog appears

## Test plan
- [ ] Navigate to admin user management page
- [ ] Click the action menu (⋮) on any user row
- [ ] Click "删除用户" — confirmation dialog should appear
- [ ] Confirm deletion works; cancel also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where selecting "删除用户" from the admin dropdown could cause the menu to close or misbehave; confirmation and deletion now run reliably.
  * Fixed the "删除账号" option on bot cards so selecting it no longer misfires the menu; the intended confirmation and deletion flow occurs as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->