### PR TITLE
fix: eliminate nested scrolling with data-full-page attribute

### DIFF
--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -526,8 +526,8 @@ export function Layout() {
           <SecurityBanner />
         )}
 
-        <main className="flex-1 overflow-y-auto overflow-x-hidden">
-          <div className="h-full mx-auto w-full max-w-[1400px] p-6 lg:p-8 animate-in fade-in slide-in-from-bottom-2 duration-500">
+        <main className="flex-1 overflow-y-auto overflow-x-hidden [&:has([data-full-page])]:overflow-hidden">
+          <div className="h-full mx-auto w-full max-w-[1400px] p-6 lg:p-8 animate-in fade-in slide-in-from-bottom-2 duration-500 [&:has([data-full-page])]:p-0 [&:has([data-full-page])]:max-w-none">
             <Outlet />
           </div>
         </main>

--- a/web/src/pages/console/console-page.tsx
+++ b/web/src/pages/console/console-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { useParams, Link } from "react-router-dom";
 import {
   ArrowLeft,
@@ -52,16 +52,6 @@ export function ConsolePage() {
   const dragDepthRef = useRef(0);
   const stagedPreviewRef = useRef<string | null>(null);
 
-  // Lock parent <main> scroll so console manages its own height
-  useLayoutEffect(() => {
-    const main = document.querySelector("main");
-    if (!main) return;
-    const prev = main.style.overflow;
-    main.style.overflow = "hidden";
-    return () => {
-      main.style.overflow = prev;
-    };
-  }, []);
 
   const fetchData = useCallback(async () => {
     if (!botId) return;
@@ -227,7 +217,8 @@ export function ConsolePage() {
 
   return (
     <div
-      className="relative flex flex-col h-full -m-6 lg:-m-8"
+      data-full-page
+      className="relative flex flex-col h-full"
       onDragEnter={onDragEnter}
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}


### PR DESCRIPTION
## Summary

Closes #174

消息页面（Console）存在嵌套滚动问题，原因是 layout 的 `<main>` 有 `overflow-y-auto`，Console 内部又有自己的滚动容器。

**方案**：引入 `data-full-page` 属性，让页面声明自己是「面板型」（需要自管滚动）。Layout 通过 CSS `:has()` 自动响应：关闭 main 的滚动、移除 padding 和 max-width 限制。

**改动**：
- `layout.tsx`：main 和内层 div 增加 `:has([data-full-page])` 响应样式
- `console-page.tsx`：移除 `useLayoutEffect` workaround 和负 margin hack，改用 `data-full-page`

未来任何全屏页面只需在根元素加 `data-full-page` 即可。

## Test plan

- [ ] Console 页面无嵌套滚动，消息列表正常滚动
- [ ] Console 页面 input 固定在底部
- [ ] 其他页面（Settings, Bots, Dashboard 等）滚动行为不变
- [ ] 窗口缩放时 Console 布局正确