### PR TITLE
fix: use dynamic protocol detection for WebSocket URLs in UI

### DIFF
--- a/web/src/pages/app-detail.tsx
+++ b/web/src/pages/app-detail.tsx
@@ -336,7 +336,7 @@ function BasicInfoSection({ app, onUpdate }: { app: any; onUpdate: () => void })
   -H "Authorization: Bearer <your_token>" \\
   -d '{"content":"hello"}'`}</pre>
             <p className="font-sans text-xs font-medium text-foreground">WebSocket 连接</p>
-            <pre className="p-2 rounded-md bg-muted/30 border overflow-x-auto whitespace-pre-wrap">{`wss://${window.location.origin.replace(/^https?:\/\//, "")}/bot/v1/ws?token=<your_token>`}</pre>
+            <pre className="p-2 rounded-md bg-muted/30 border overflow-x-auto whitespace-pre-wrap">{`${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/bot/v1/ws?token=<your_token>`}</pre>
           </CardContent>
         </Card>
       ) : null}
@@ -398,7 +398,7 @@ function IntegrationTokenGuide({ app }: { app: any }) {
         </div>
         <div className="space-y-1">
           <p className="font-medium text-foreground">WebSocket 连接</p>
-          <pre className="p-2 rounded-md bg-muted/30 border font-mono overflow-x-auto whitespace-pre-wrap">{`wss://${hubUrl.replace(/^https?:\/\//, "")}/bot/v1/ws?token={token}`}</pre>
+          <pre className="p-2 rounded-md bg-muted/30 border font-mono overflow-x-auto whitespace-pre-wrap">{`${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/bot/v1/ws?token={token}`}</pre>
         </div>
       </CardContent>
     </Card>

--- a/web/src/pages/channel-detail.tsx
+++ b/web/src/pages/channel-detail.tsx
@@ -310,7 +310,7 @@ export function ChannelDetailPage() {
               <div className="rounded-lg bg-muted/50 p-4 border font-mono text-[11px] space-y-4 leading-relaxed">
                 <div>
                   <p className="text-primary font-bold mb-1">// WebSocket（实时推送）</p>
-                  <code className="block bg-background p-2 rounded border">{`ws://${window.location.host}/api/v1/channels/connect?key=${channel.api_key.slice(0, 12)}...`}</code>
+                  <code className="block bg-background p-2 rounded border">{`${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/api/v1/channels/connect?key=${channel.api_key.slice(0, 12)}...`}</code>
                 </div>
                 <div>
                   <p className="text-primary font-bold mb-1">// HTTP POST（发送回复）</p>

--- a/web/src/pages/installation-detail.tsx
+++ b/web/src/pages/installation-detail.tsx
@@ -590,7 +590,7 @@ function TokenSection({ app, inst }: { app: any; inst: any }) {
                 WebSocket 连接
               </summary>
               <pre className="mt-2 p-3 rounded-md bg-muted/30 border text-xs font-mono overflow-x-auto whitespace-pre-wrap">
-                {`wss://${hubUrl.replace(/^https?:\/\//, "")}/bot/v1/ws?token=${token || "<your_token>"}`}
+                {`${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/bot/v1/ws?token=${token || "<your_token>"}`}
               </pre>
             </details>
 


### PR DESCRIPTION
## Summary
- UI 中展示的 WebSocket 地址之前硬编码了 `ws://` 或 `wss://` 协议，导致在 http/https 不同环境下地址拼接有误
- 统一改为根据 `window.location.protocol` 动态选择 `ws://` 或 `wss://`，与项目中已有的 WebSocket 连接代码保持一致

Closes #191

## Test plan
- [ ] 在 http 环境下查看 channel-detail、app-detail、installation-detail 页面，确认 WebSocket 地址显示为 `ws://`
- [ ] 在 https 环境下查看同样页面，确认 WebSocket 地址显示为 `wss://`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket connection URLs now dynamically adapt to match the current page's protocol, ensuring secure (`wss://`) connections on HTTPS pages and standard (`ws://`) connections on HTTP pages for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->