### PR TITLE
fix(bridge): fix message not forwarded due to double-encoded config

### DIFF
--- a/internal/api/app_install_handler.go
+++ b/internal/api/app_install_handler.go
@@ -90,15 +90,12 @@ func (s *Server) handleUpdateInstallation(w http.ResponseWriter, r *http.Request
 	if req.Config != nil {
 		// Unwrap double-encoded config JSON strings (e.g., sent as a quoted
 		// string instead of a raw object due to a prior frontend bug).
-		var s string
-		if json.Unmarshal(req.Config, &s) == nil {
-			if unwrapped := json.RawMessage(s); json.Valid(unwrapped) {
+		cfg = req.Config
+		var raw string
+		if json.Unmarshal(req.Config, &raw) == nil {
+			if unwrapped := json.RawMessage(raw); json.Valid(unwrapped) && len(unwrapped) > 0 && unwrapped[0] == '{' {
 				cfg = unwrapped
-			} else {
-				cfg = req.Config
 			}
-		} else {
-			cfg = req.Config
 		}
 	}
 	enabled := inst.Enabled

--- a/internal/api/app_install_handler.go
+++ b/internal/api/app_install_handler.go
@@ -88,7 +88,18 @@ func (s *Server) handleUpdateInstallation(w http.ResponseWriter, r *http.Request
 	}
 	cfg := inst.Config
 	if req.Config != nil {
-		cfg = req.Config
+		// Unwrap double-encoded config JSON strings (e.g., sent as a quoted
+		// string instead of a raw object due to a prior frontend bug).
+		var s string
+		if json.Unmarshal(req.Config, &s) == nil {
+			if unwrapped := json.RawMessage(s); json.Valid(unwrapped) {
+				cfg = unwrapped
+			} else {
+				cfg = req.Config
+			}
+		} else {
+			cfg = req.Config
+		}
 	}
 	enabled := inst.Enabled
 	if req.Enabled != nil {

--- a/internal/api/app_install_handler_test.go
+++ b/internal/api/app_install_handler_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// TestHandleUpdateInstallation_ConfigUnwrap verifies that the write-path
+// unwrap logic in handleUpdateInstallation stores the same canonical JSON
+// regardless of whether the client sends a raw object or a double-encoded
+// string, and that non-object JSON strings are NOT unwrapped.
+func TestHandleUpdateInstallation_ConfigUnwrap(t *testing.T) {
+	env := setupTestEnv(t)
+	bot := createTestBot(t, env.store, env.user.ID, "unwrap-bot")
+	app := createTestApp(t, env.store, env.user.ID, "unwrap-app", "unwrap-app", []string{"config:write"})
+	inst := installTestApp(t, env.store, app.ID, bot.ID)
+
+	basePath := fmt.Sprintf("/api/apps/%s/installations/%s", app.ID, inst.ID)
+
+	// readConfig fetches the stored config via GET.
+	readConfig := func(t *testing.T) json.RawMessage {
+		t.Helper()
+		resp := doJSON(t, env.ts, "GET", basePath, nil, withCookie(env.cookie))
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET installation: expected 200, got %d", resp.StatusCode)
+		}
+		var result struct {
+			Config json.RawMessage `json:"config"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode GET response: %v", err)
+		}
+		return result.Config
+	}
+
+	// putConfig sends a PUT with the raw body bytes as the "config" field.
+	putConfig := func(t *testing.T, configValue any) {
+		t.Helper()
+		body := map[string]any{"config": configValue}
+		resp := doJSON(t, env.ts, "PUT", basePath, body, withCookie(env.cookie))
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("PUT installation: expected 200, got %d", resp.StatusCode)
+		}
+	}
+
+	const wantForwardURL = "https://example.com/webhook"
+
+	t.Run("normal object config is stored as-is", func(t *testing.T) {
+		putConfig(t, map[string]string{"forward_url": wantForwardURL})
+
+		got := readConfig(t)
+		var parsed map[string]string
+		if err := json.Unmarshal(got, &parsed); err != nil {
+			t.Fatalf("stored config is not a JSON object: %v (raw: %s)", err, got)
+		}
+		if parsed["forward_url"] != wantForwardURL {
+			t.Errorf("forward_url = %q, want %q", parsed["forward_url"], wantForwardURL)
+		}
+	})
+
+	t.Run("double-encoded object config is unwrapped", func(t *testing.T) {
+		// Simulate the legacy frontend bug: JSON.stringify called twice, so the
+		// wire value is a JSON string whose contents are the real object.
+		inner, _ := json.Marshal(map[string]string{"forward_url": wantForwardURL})
+		doubleEncoded := string(inner) // will be marshalled again as a JSON string by doJSON
+
+		putConfig(t, doubleEncoded)
+
+		got := readConfig(t)
+		var parsed map[string]string
+		if err := json.Unmarshal(got, &parsed); err != nil {
+			t.Fatalf("double-encoded config was not unwrapped to object: %v (raw: %s)", err, got)
+		}
+		if parsed["forward_url"] != wantForwardURL {
+			t.Errorf("forward_url = %q, want %q", parsed["forward_url"], wantForwardURL)
+		}
+	})
+
+	t.Run("JSON string that is not an object is NOT unwrapped", func(t *testing.T) {
+		// Sending config: "[]" — a JSON string whose contents are an array.
+		// The unwrap guard (unwrapped[0] == '{') must prevent clobbering.
+		putConfig(t, "[]")
+
+		got := readConfig(t)
+		// The stored value must still be the literal string "[]", not the
+		// parsed array []. That is: the raw bytes should be `"[]"` not `[]`.
+		if string(got) != `"[]"` {
+			t.Errorf("non-object JSON string was incorrectly unwrapped: got %s, want %q", got, `"[]"`)
+		}
+	})
+}

--- a/internal/builtin/bridge/handler.go
+++ b/internal/builtin/bridge/handler.go
@@ -26,7 +26,15 @@ type bridgeConfig struct {
 
 func (h *Handler) HandleEvent(inst *store.AppInstallation, event *app.Event) error {
 	var cfg bridgeConfig
-	if err := json.Unmarshal(inst.Config, &cfg); err != nil || cfg.ForwardURL == "" {
+	if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+		// Attempt to unwrap double-encoded config (stored as a JSON string
+		// instead of a JSON object due to a prior frontend bug, issue #197).
+		var s string
+		if json.Unmarshal(inst.Config, &s) == nil {
+			json.Unmarshal([]byte(s), &cfg)
+		}
+	}
+	if cfg.ForwardURL == "" {
 		return nil // not configured, skip silently
 	}
 

--- a/internal/builtin/bridge/handler.go
+++ b/internal/builtin/bridge/handler.go
@@ -27,11 +27,12 @@ type bridgeConfig struct {
 func (h *Handler) HandleEvent(inst *store.AppInstallation, event *app.Event) error {
 	var cfg bridgeConfig
 	if err := json.Unmarshal(inst.Config, &cfg); err != nil {
-		// Attempt to unwrap double-encoded config (stored as a JSON string
-		// instead of a JSON object due to a prior frontend bug, issue #197).
-		var s string
-		if json.Unmarshal(inst.Config, &s) == nil {
-			json.Unmarshal([]byte(s), &cfg)
+		// TODO: remove after data migration — unwrap double-encoded config
+		// (stored as a JSON string instead of a JSON object due to a prior
+		// frontend bug, issue #197).
+		var raw string
+		if json.Unmarshal(inst.Config, &raw) == nil && len(raw) > 0 && raw[0] == '{' {
+			json.Unmarshal([]byte(raw), &cfg)
 		}
 	}
 	if cfg.ForwardURL == "" {

--- a/internal/builtin/bridge/handler_test.go
+++ b/internal/builtin/bridge/handler_test.go
@@ -149,3 +149,36 @@ func TestHandler_InvalidURL(t *testing.T) {
 		t.Fatal("expected error for unreachable URL")
 	}
 }
+
+// TestHandler_DoubleEncodedConfig verifies that a double-serialized config
+// (a JSON string instead of a JSON object, as produced by the old frontend
+// bug: JSON.stringify in config field + JSON.stringify in request body)
+// causes the handler to silently skip forwarding — reproducing issue #197.
+func TestHandler_DoubleEncodedConfig(t *testing.T) {
+	forwarded := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwarded = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	// Config is a JSON-encoded string (double-encode: the frontend did JSON.stringify twice)
+	doubleEncoded, _ := json.Marshal(`{"forward_url":"` + ts.URL + `"}`)
+
+	inst := &store.AppInstallation{
+		ID:               "inst-bug",
+		BotID:            "bot-456",
+		Config:           json.RawMessage(doubleEncoded),
+		AppWebhookSecret: "test-secret",
+	}
+	event := &app.Event{Type: "message.text", ID: "evt-000"}
+
+	h := &Handler{}
+	_ = h.HandleEvent(inst, event)
+
+	if forwarded {
+		t.Log("forwarded=true: backend unwrapping fix is active")
+	} else {
+		t.Error("BUG REPRODUCED: double-encoded config causes silent skip — message NOT forwarded (issue #197)")
+	}
+}

--- a/web/src/pages/install-app.tsx
+++ b/web/src/pages/install-app.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
-import { ArrowLeft, Eye, Zap, Loader2, ExternalLink, ShieldCheck, Terminal, Sliders } from "lucide-react";
+import {
+  ArrowLeft,
+  Eye,
+  Zap,
+  Loader2,
+  ExternalLink,
+  ShieldCheck,
+  Terminal,
+  Sliders,
+} from "lucide-react";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
 import { Input } from "../components/ui/input";
@@ -98,7 +107,11 @@ export function InstallAppPage() {
 
       if (result?.needs_oauth && result?.oauth_redirect) {
         setWaitingForOAuth(true);
-        const popup = window.open(result.oauth_redirect, "oauth_popup", "width=600,height=700,scrollbars=yes");
+        const popup = window.open(
+          result.oauth_redirect,
+          "oauth_popup",
+          "width=600,height=700,scrollbars=yes",
+        );
         setOAuthPopup(popup);
         setInstalling(false);
         return;
@@ -111,7 +124,7 @@ export function InstallAppPage() {
         if (hasConfig) {
           try {
             await api.updateInstallation(appId!, installationId, {
-              config: JSON.stringify(configForm),
+              config: configForm,
             });
           } catch {
             toast({ title: "配置保存失败", description: "应用已安装，但配置未保存。" });
@@ -134,11 +147,17 @@ export function InstallAppPage() {
       <div className="max-w-xl mx-auto py-20 text-center space-y-4">
         <Loader2 className="h-8 w-8 animate-spin mx-auto text-primary" />
         <h2 className="text-lg font-bold">等待授权完成</h2>
-        <p className="text-sm text-muted-foreground">请在弹出窗口中完成应用授权。完成后此页面将自动更新。</p>
-        <Button variant="outline" size="sm" onClick={() => {
-          setWaitingForOAuth(false);
-          if (oauthPopup && !oauthPopup.closed) oauthPopup.close();
-        }}>
+        <p className="text-sm text-muted-foreground">
+          请在弹出窗口中完成应用授权。完成后此页面将自动更新。
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            setWaitingForOAuth(false);
+            if (oauthPopup && !oauthPopup.closed) oauthPopup.close();
+          }}
+        >
           取消
         </Button>
       </div>
@@ -171,15 +190,15 @@ export function InstallAppPage() {
   const writeScopes = scopes.filter((s: string) => s.endsWith(":write"));
   const otherScopes = scopes.filter((s: string) => !s.endsWith(":read") && !s.endsWith(":write"));
   const events: string[] = app.events || [];
-  const hasPermissions = readScopes.length > 0 || writeScopes.length > 0 || otherScopes.length > 0 || events.length > 0;
+  const hasPermissions =
+    readScopes.length > 0 || writeScopes.length > 0 || otherScopes.length > 0 || events.length > 0;
 
   // Parse config_schema
   let schemaProperties: Record<string, any> = {};
   if (app.config_schema) {
     try {
-      const parsed = typeof app.config_schema === "string"
-        ? JSON.parse(app.config_schema)
-        : app.config_schema;
+      const parsed =
+        typeof app.config_schema === "string" ? JSON.parse(app.config_schema) : app.config_schema;
       schemaProperties = parsed.properties || {};
     } catch {
       // ignore
@@ -234,9 +253,7 @@ export function InstallAppPage() {
               </a>
             )}
           </div>
-          {app.description && (
-            <p className="text-sm text-muted-foreground">{app.description}</p>
-          )}
+          {app.description && <p className="text-sm text-muted-foreground">{app.description}</p>}
           <div className="flex items-center gap-3 pt-2">
             <div className="flex items-center gap-2">
               <Input
@@ -267,7 +284,9 @@ export function InstallAppPage() {
             className="w-full h-9 px-3 rounded-md border bg-background text-sm"
           >
             {tabs.map((t) => (
-              <option key={t.key} value={t.key}>{t.label}</option>
+              <option key={t.key} value={t.key}>
+                {t.label}
+              </option>
             ))}
           </select>
         </div>
@@ -308,13 +327,20 @@ export function InstallAppPage() {
                   <CardContent className="pt-6 space-y-4">
                     {readScopes.length > 0 && (
                       <div className="space-y-2">
-                        <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">读取权限</p>
+                        <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                          读取权限
+                        </p>
                         <div className="space-y-1.5">
                           {readScopes.map((scope: string) => (
-                            <div key={scope} className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <div
+                              key={scope}
+                              className="flex items-center gap-2 text-sm text-muted-foreground"
+                            >
                               <Eye className="h-3.5 w-3.5 shrink-0" />
                               <span>{SCOPE_DESCRIPTIONS[scope] || scope}</span>
-                              <span className="font-mono text-xs ml-auto text-muted-foreground/60">{scope}</span>
+                              <span className="font-mono text-xs ml-auto text-muted-foreground/60">
+                                {scope}
+                              </span>
                             </div>
                           ))}
                         </div>
@@ -322,13 +348,20 @@ export function InstallAppPage() {
                     )}
                     {writeScopes.length > 0 && (
                       <div className="space-y-2">
-                        <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">写入权限</p>
+                        <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                          写入权限
+                        </p>
                         <div className="space-y-1.5">
                           {writeScopes.map((scope: string) => (
-                            <div key={scope} className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <div
+                              key={scope}
+                              className="flex items-center gap-2 text-sm text-muted-foreground"
+                            >
                               <Zap className="h-3.5 w-3.5 shrink-0" />
                               <span>{SCOPE_DESCRIPTIONS[scope] || scope}</span>
-                              <span className="font-mono text-xs ml-auto text-muted-foreground/60">{scope}</span>
+                              <span className="font-mono text-xs ml-auto text-muted-foreground/60">
+                                {scope}
+                              </span>
                             </div>
                           ))}
                         </div>
@@ -336,13 +369,20 @@ export function InstallAppPage() {
                     )}
                     {otherScopes.length > 0 && (
                       <div className="space-y-2">
-                        <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">其他权限</p>
+                        <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                          其他权限
+                        </p>
                         <div className="space-y-1.5">
                           {otherScopes.map((scope: string) => (
-                            <div key={scope} className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <div
+                              key={scope}
+                              className="flex items-center gap-2 text-sm text-muted-foreground"
+                            >
                               <ShieldCheck className="h-3.5 w-3.5 shrink-0" />
                               <span>{SCOPE_DESCRIPTIONS[scope] || scope}</span>
-                              <span className="font-mono text-xs ml-auto text-muted-foreground/60">{scope}</span>
+                              <span className="font-mono text-xs ml-auto text-muted-foreground/60">
+                                {scope}
+                              </span>
                             </div>
                           ))}
                         </div>
@@ -350,14 +390,20 @@ export function InstallAppPage() {
                     )}
                     {events.length > 0 && (
                       <div className="space-y-2">
-                        <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">订阅事件</p>
+                        <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                          订阅事件
+                        </p>
                         <div className="flex flex-wrap gap-1.5">
                           {events.map((event: string) => {
                             const found = EVENT_TYPES.find((e) => e.key === event);
                             return (
                               <Badge key={event} variant="outline" className="text-xs">
                                 {found ? found.label : event}
-                                {found && <span className="font-mono text-muted-foreground/60 ml-1">· {event}</span>}
+                                {found && (
+                                  <span className="font-mono text-muted-foreground/60 ml-1">
+                                    · {event}
+                                  </span>
+                                )}
                               </Badge>
                             );
                           })}

--- a/web/src/pages/install-app.tsx
+++ b/web/src/pages/install-app.tsx
@@ -59,16 +59,30 @@ export function InstallAppPage() {
   const [installing, setInstalling] = useState(false);
   const [waitingForOAuth, setWaitingForOAuth] = useState(false);
   const [oauthPopup, setOAuthPopup] = useState<Window | null>(null);
+  const [oauthInstallationId, setOAuthInstallationId] = useState<string | null>(null);
   const [tab, setTab] = useState<TabKey>("permissions");
+
+  // Save config for an installation if the app has a config_schema and the user filled values.
+  async function saveConfigIfNeeded(installationId: string) {
+    if (!app?.config_schema || !installationId) return;
+    const hasConfig = Object.values(configForm).some((v) => v !== "");
+    if (!hasConfig) return;
+    try {
+      await api.updateInstallation(appId!, installationId, { config: configForm });
+    } catch {
+      toast({ title: "配置保存失败", description: "应用已安装，但配置未保存。" });
+    }
+  }
 
   // Listen for OAuth completion from popup
   useEffect(() => {
     if (!waitingForOAuth) return;
 
-    const handleMessage = (event: MessageEvent) => {
+    const handleMessage = async (event: MessageEvent) => {
       if (event.data?.type === "oauth_complete") {
         setWaitingForOAuth(false);
         if (oauthPopup && !oauthPopup.closed) oauthPopup.close();
+        if (oauthInstallationId) await saveConfigIfNeeded(oauthInstallationId);
         invalidateAppQueries();
         toast({ title: "安装成功" });
         navigate(`/dashboard/accounts/${botId}`);
@@ -79,10 +93,12 @@ export function InstallAppPage() {
     const interval = setInterval(async () => {
       try {
         const installations = await api.listBotApps(botId!);
-        if (installations?.find((i: any) => i.app_id === appId)) {
+        const found = installations?.find((i: any) => i.app_id === appId);
+        if (found) {
           clearInterval(interval);
           setWaitingForOAuth(false);
           if (oauthPopup && !oauthPopup.closed) oauthPopup.close();
+          await saveConfigIfNeeded(found.id);
           invalidateAppQueries();
           toast({ title: "安装成功" });
           navigate(`/dashboard/accounts/${botId}`);
@@ -94,7 +110,7 @@ export function InstallAppPage() {
       window.removeEventListener("message", handleMessage);
       clearInterval(interval);
     };
-  }, [waitingForOAuth, oauthPopup, botId, appId, navigate, toast]);
+  }, [waitingForOAuth, oauthPopup, oauthInstallationId, botId, appId, navigate, toast]);
 
   async function handleInstall() {
     setInstalling(true);
@@ -106,6 +122,8 @@ export function InstallAppPage() {
       });
 
       if (result?.needs_oauth && result?.oauth_redirect) {
+        const instId = result?.id || result?.installation_id;
+        if (instId) setOAuthInstallationId(instId);
         setWaitingForOAuth(true);
         const popup = window.open(
           result.oauth_redirect,
@@ -118,19 +136,7 @@ export function InstallAppPage() {
       }
 
       const installationId = result?.id || result?.installation_id;
-
-      if (app.config_schema && installationId) {
-        const hasConfig = Object.values(configForm).some((v) => v !== "");
-        if (hasConfig) {
-          try {
-            await api.updateInstallation(appId!, installationId, {
-              config: configForm,
-            });
-          } catch {
-            toast({ title: "配置保存失败", description: "应用已安装，但配置未保存。" });
-          }
-        }
-      }
+      if (installationId) await saveConfigIfNeeded(installationId);
 
       toast({ title: "安装成功" });
       invalidateAppQueries();

--- a/web/src/pages/install-app.tsx
+++ b/web/src/pages/install-app.tsx
@@ -59,7 +59,6 @@ export function InstallAppPage() {
   const [installing, setInstalling] = useState(false);
   const [waitingForOAuth, setWaitingForOAuth] = useState(false);
   const [oauthPopup, setOAuthPopup] = useState<Window | null>(null);
-  const [oauthInstallationId, setOAuthInstallationId] = useState<string | null>(null);
   const [tab, setTab] = useState<TabKey>("permissions");
 
   // Save config for an installation if the app has a config_schema and the user filled values.
@@ -82,7 +81,12 @@ export function InstallAppPage() {
       if (event.data?.type === "oauth_complete") {
         setWaitingForOAuth(false);
         if (oauthPopup && !oauthPopup.closed) oauthPopup.close();
-        if (oauthInstallationId) await saveConfigIfNeeded(oauthInstallationId);
+        // Look up the installation to save config (OAuth flow creates it server-side).
+        try {
+          const installations = await api.listBotApps(botId!);
+          const found = installations?.find((i: any) => i.app_id === appId);
+          if (found) await saveConfigIfNeeded(found.id);
+        } catch {}
         invalidateAppQueries();
         toast({ title: "安装成功" });
         navigate(`/dashboard/accounts/${botId}`);
@@ -110,7 +114,7 @@ export function InstallAppPage() {
       window.removeEventListener("message", handleMessage);
       clearInterval(interval);
     };
-  }, [waitingForOAuth, oauthPopup, oauthInstallationId, botId, appId, navigate, toast]);
+  }, [waitingForOAuth, oauthPopup, botId, appId, navigate, toast]);
 
   async function handleInstall() {
     setInstalling(true);
@@ -122,8 +126,6 @@ export function InstallAppPage() {
       });
 
       if (result?.needs_oauth && result?.oauth_redirect) {
-        const instId = result?.id || result?.installation_id;
-        if (instId) setOAuthInstallationId(instId);
         setWaitingForOAuth(true);
         const popup = window.open(
           result.oauth_redirect,

--- a/web/src/pages/installation-detail.tsx
+++ b/web/src/pages/installation-detail.tsx
@@ -23,13 +23,7 @@ import {
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
 import { Input } from "../components/ui/input";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  CardDescription,
-} from "../components/ui/card";
+import { Card, CardHeader, CardTitle, CardContent, CardDescription } from "../components/ui/card";
 import {
   Table,
   TableBody,
@@ -60,7 +54,14 @@ import { ToolsDisplay, parseTools } from "../components/tools-display";
 
 // ==================== Nav Definition ====================
 
-type SectionKey = "token" | "config" | "app-config" | "tools" | "permissions" | "event-logs" | "api-logs";
+type SectionKey =
+  | "token"
+  | "config"
+  | "app-config"
+  | "tools"
+  | "permissions"
+  | "event-logs"
+  | "api-logs";
 
 function buildNavSections(app: any, inst?: any) {
   const items: { key: SectionKey; label: string; icon: any }[] = [
@@ -109,7 +110,8 @@ export function InstallationDetailPage() {
   const botName = bot ? botDisplayName(bot) : "";
   const loading = installationsLoading;
 
-  const refreshInstallations = () => queryClient.invalidateQueries({ queryKey: queryKeys.bots.apps(botId!) });
+  const refreshInstallations = () =>
+    queryClient.invalidateQueries({ queryKey: queryKeys.bots.apps(botId!) });
 
   // Local UI state
   const [section, setSection] = useState<SectionKey>("token");
@@ -204,10 +206,7 @@ export function InstallationDetailPage() {
           <div className="flex-1 min-w-0 space-y-1">
             <div className="flex items-center gap-3 flex-wrap">
               <h1 className="text-2xl font-bold tracking-tight">{inst.app_name || app.name}</h1>
-              <InlineHandleEditor
-                value={handle}
-                onSave={handleSaveHandle}
-              />
+              <InlineHandleEditor value={handle} onSave={handleSaveHandle} />
               {app.registry && app.registry !== "builtin" ? (
                 <Badge variant="outline" className="rounded-full font-bold">
                   来自应用市场
@@ -308,14 +307,18 @@ export function InstallationDetailPage() {
               );
             })()}
           {section === "permissions" && <PermissionsSection app={app} inst={inst} />}
-          {section === "app-config" && <AppConfigForm app={app} inst={inst} onUpdate={refreshInstallations} />}
+          {section === "app-config" && (
+            <AppConfigForm app={app} inst={inst} onUpdate={refreshInstallations} />
+          )}
           {section === "config" && (
             <ConfigSection
               inst={inst}
               onUninstall={() => navigate(`/dashboard/accounts/${botId}`)}
             />
           )}
-          {section === "event-logs" && <EventLogsSection appId={inst.app_id} instId={inst.id} botId={botId!} />}
+          {section === "event-logs" && (
+            <EventLogsSection appId={inst.app_id} instId={inst.id} botId={botId!} />
+          )}
           {section === "api-logs" && <ApiLogsSection appId={inst.app_id} instId={inst.id} />}
         </div>
       </div>
@@ -325,13 +328,7 @@ export function InstallationDetailPage() {
 
 // ==================== Inline Handle Editor ====================
 
-function InlineHandleEditor({
-  value,
-  onSave,
-}: {
-  value: string;
-  onSave: (v: string) => void;
-}) {
+function InlineHandleEditor({ value, onSave }: { value: string; onSave: (v: string) => void }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -425,7 +422,11 @@ function TokenSection({ app, inst }: { app: any; inst: any }) {
 
   function handleCopy(text: string) {
     if (!navigator.clipboard?.writeText) {
-      toast({ variant: "destructive", title: "复制失败", description: "当前浏览器不支持自动复制，请手动选中复制" });
+      toast({
+        variant: "destructive",
+        title: "复制失败",
+        description: "当前浏览器不支持自动复制，请手动选中复制",
+      });
       return;
     }
     navigator.clipboard
@@ -479,30 +480,57 @@ function TokenSection({ app, inst }: { app: any; inst: any }) {
       btn.textContent = "复制";
       btn.setAttribute("aria-label", "复制代码");
       Object.assign(btn.style, {
-        position: "absolute", top: "6px", right: "6px",
-        fontSize: "11px", padding: "2px 8px", borderRadius: "4px",
-        border: "1px solid var(--border)", background: "var(--background)",
-        color: "var(--muted-foreground)", cursor: "pointer",
+        position: "absolute",
+        top: "6px",
+        right: "6px",
+        fontSize: "11px",
+        padding: "2px 8px",
+        borderRadius: "4px",
+        border: "1px solid var(--border)",
+        background: "var(--background)",
+        color: "var(--muted-foreground)",
+        cursor: "pointer",
       });
       btn.addEventListener("click", () => {
         if (!navigator.clipboard?.writeText) {
           btn.textContent = "失败";
-          toast({ variant: "destructive", title: "复制失败", description: "当前浏览器不支持自动复制，请手动选中复制" });
-          timeouts.push(setTimeout(() => { btn.textContent = "复制"; }, 2000));
+          toast({
+            variant: "destructive",
+            title: "复制失败",
+            description: "当前浏览器不支持自动复制，请手动选中复制",
+          });
+          timeouts.push(
+            setTimeout(() => {
+              btn.textContent = "复制";
+            }, 2000),
+          );
           return;
         }
-        navigator.clipboard.writeText(codeText).then(() => {
-          btn.textContent = "已复制";
-          timeouts.push(setTimeout(() => { btn.textContent = "复制"; }, 2000));
-        }).catch(() => {
-          btn.textContent = "失败";
-          toast({ variant: "destructive", title: "复制失败", description: "请手动选中复制" });
-          timeouts.push(setTimeout(() => { btn.textContent = "复制"; }, 2000));
-        });
+        navigator.clipboard
+          .writeText(codeText)
+          .then(() => {
+            btn.textContent = "已复制";
+            timeouts.push(
+              setTimeout(() => {
+                btn.textContent = "复制";
+              }, 2000),
+            );
+          })
+          .catch(() => {
+            btn.textContent = "失败";
+            toast({ variant: "destructive", title: "复制失败", description: "请手动选中复制" });
+            timeouts.push(
+              setTimeout(() => {
+                btn.textContent = "复制";
+              }, 2000),
+            );
+          });
       });
       pre.appendChild(btn);
     });
-    return () => { timeouts.forEach(clearTimeout); };
+    return () => {
+      timeouts.forEach(clearTimeout);
+    };
   }, [guideHtml]);
   const showGenericGuide = !guideText && app.registry === "builtin";
   const showUsageGuide = guideText || showGenericGuide;
@@ -650,7 +678,7 @@ function AppConfigForm({ app, inst, onUpdate }: { app: any; inst: any; onUpdate:
     setSaving(true);
     try {
       await api.updateInstallation(inst.app_id, inst.id, {
-        config: JSON.stringify(form),
+        config: form,
       });
       toast({ title: "配置已保存" });
       onUpdate();
@@ -697,13 +725,7 @@ function AppConfigForm({ app, inst, onUpdate }: { app: any; inst: any; onUpdate:
 
 // ==================== Config Section ====================
 
-function ConfigSection({
-  inst,
-  onUninstall,
-}: {
-  inst: any;
-  onUninstall: () => void;
-}) {
+function ConfigSection({ inst, onUninstall }: { inst: any; onUninstall: () => void }) {
   const { toast } = useToast();
   const [showUninstallDialog, setShowUninstallDialog] = useState(false);
   const [uninstalling, setUninstalling] = useState(false);
@@ -766,7 +788,15 @@ function ConfigSection({
 
 // ==================== Event Logs Section ====================
 
-function EventLogsSection({ appId, instId, botId }: { appId: string; instId: string; botId: string }) {
+function EventLogsSection({
+  appId,
+  instId,
+  botId,
+}: {
+  appId: string;
+  instId: string;
+  botId: string;
+}) {
   const navigate = useNavigate();
   const [logs, setLogs] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
@@ -844,8 +874,15 @@ function EventLogsSection({ appId, instId, botId }: { appId: string; instId: str
                   key={log.id || log.trace_id + log.created_at}
                   className={log.trace_id ? "cursor-pointer focus-visible:bg-muted/50" : ""}
                   tabIndex={log.trace_id ? 0 : undefined}
-                  onClick={() => log.trace_id && navigate(`/dashboard/accounts/${botId}/traces/${log.trace_id}`)}
-                  onKeyDown={(e) => { if (log.trace_id && (e.key === "Enter" || e.key === " ")) { e.preventDefault(); navigate(`/dashboard/accounts/${botId}/traces/${log.trace_id}`); } }}
+                  onClick={() =>
+                    log.trace_id && navigate(`/dashboard/accounts/${botId}/traces/${log.trace_id}`)
+                  }
+                  onKeyDown={(e) => {
+                    if (log.trace_id && (e.key === "Enter" || e.key === " ")) {
+                      e.preventDefault();
+                      navigate(`/dashboard/accounts/${botId}/traces/${log.trace_id}`);
+                    }
+                  }}
                 >
                   <TableCell className="font-mono whitespace-nowrap">
                     {formatTime(log.created_at)}
@@ -989,9 +1026,7 @@ function PermissionsSection({ app, inst }: { app: any; inst: any }) {
   const events: string[] = app?.events || [];
   const readScopes = scopes.filter((s: string) => s.endsWith(":read"));
   const writeScopes = scopes.filter((s: string) => s.endsWith(":write"));
-  const otherScopes = scopes.filter(
-    (s: string) => !s.endsWith(":read") && !s.endsWith(":write")
-  );
+  const otherScopes = scopes.filter((s: string) => !s.endsWith(":read") && !s.endsWith(":write"));
 
   function eventLabelEntry(key: string): { label: string; showKey: boolean } {
     const found = EVENT_TYPES.find((e) => e.key === key);
@@ -1009,13 +1044,20 @@ function PermissionsSection({ app, inst }: { app: any; inst: any }) {
         <CardContent className="pt-6 space-y-4">
           {readScopes.length > 0 && (
             <div className="space-y-2">
-              <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">读取权限</p>
+              <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                读取权限
+              </p>
               <div className="space-y-1.5">
                 {readScopes.map((scope: string) => (
-                  <div key={scope} className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <div
+                    key={scope}
+                    className="flex items-center gap-2 text-sm text-muted-foreground"
+                  >
                     <Eye className="h-3.5 w-3.5 shrink-0" />
                     <span>{SCOPE_DESCRIPTIONS[scope] || scope}</span>
-                    <span className="font-mono text-xs ml-auto text-muted-foreground/60">{scope}</span>
+                    <span className="font-mono text-xs ml-auto text-muted-foreground/60">
+                      {scope}
+                    </span>
                   </div>
                 ))}
               </div>
@@ -1024,13 +1066,20 @@ function PermissionsSection({ app, inst }: { app: any; inst: any }) {
 
           {writeScopes.length > 0 && (
             <div className="space-y-2">
-              <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">写入权限</p>
+              <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                写入权限
+              </p>
               <div className="space-y-1.5">
                 {writeScopes.map((scope: string) => (
-                  <div key={scope} className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <div
+                    key={scope}
+                    className="flex items-center gap-2 text-sm text-muted-foreground"
+                  >
                     <Zap className="h-3.5 w-3.5 shrink-0" />
                     <span>{SCOPE_DESCRIPTIONS[scope] || scope}</span>
-                    <span className="font-mono text-xs ml-auto text-muted-foreground/60">{scope}</span>
+                    <span className="font-mono text-xs ml-auto text-muted-foreground/60">
+                      {scope}
+                    </span>
                   </div>
                 ))}
               </div>
@@ -1039,13 +1088,20 @@ function PermissionsSection({ app, inst }: { app: any; inst: any }) {
 
           {otherScopes.length > 0 && (
             <div className="space-y-2">
-              <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">其他权限</p>
+              <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                其他权限
+              </p>
               <div className="space-y-1.5">
                 {otherScopes.map((scope: string) => (
-                  <div key={scope} className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <div
+                    key={scope}
+                    className="flex items-center gap-2 text-sm text-muted-foreground"
+                  >
                     <ShieldCheck className="h-3.5 w-3.5 shrink-0" />
                     <span>{SCOPE_DESCRIPTIONS[scope] || scope}</span>
-                    <span className="font-mono text-xs ml-auto text-muted-foreground/60">{scope}</span>
+                    <span className="font-mono text-xs ml-auto text-muted-foreground/60">
+                      {scope}
+                    </span>
                   </div>
                 ))}
               </div>
@@ -1054,14 +1110,18 @@ function PermissionsSection({ app, inst }: { app: any; inst: any }) {
 
           {events.length > 0 && (
             <div className="space-y-2">
-              <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">订阅事件</p>
+              <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                订阅事件
+              </p>
               <div className="flex flex-wrap gap-1.5">
                 {events.map((event: string) => {
                   const { label, showKey } = eventLabelEntry(event);
                   return (
                     <Badge key={event} variant="outline" className="text-xs">
                       {label}
-                      {showKey && <span className="font-mono text-muted-foreground/60 ml-1">· {event}</span>}
+                      {showKey && (
+                        <span className="font-mono text-muted-foreground/60 ml-1">· {event}</span>
+                      )}
                     </Badge>
                   );
                 })}


### PR DESCRIPTION
## Problem / Intent

Fixes #197. The Bridge plugin failed to forward messages to the callback URL after installation.

Root cause: the frontend double-serialized the installation config — `JSON.stringify` was called explicitly in the `config` field, and then `api.ts` serialized the entire request body again. This caused the DB to store the config as a JSON-encoded string (e.g. `"{\"forward_url\":\"...\"}"`) instead of a JSON object. The bridge handler's `json.Unmarshal` then failed silently and returned early, skipping the forward entirely.

## Approach

- **Frontend fix**: remove the redundant `JSON.stringify` in `install-app.tsx` and `installation-detail.tsx` — pass the raw config object directly
- **Backend API defense**: `handleUpdateInstallation` now detects and unwraps double-encoded config on new saves, fixing data going forward
- **Bridge handler defense**: handler now attempts to unwrap double-encoded config on read, recovering existing bad data without requiring users to re-save
- **Regression test**: `TestHandler_DoubleEncodedConfig` reproduces the bug (forwarded=false) and verifies the fix (forwarded=true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fix: double-encoded JSON configs are now detected and unwrapped so stored configs and event forwarding work reliably; parsing errors no longer cause silent skips.
  * Install flows now persist config as structured data and surface a “配置保存失败” toast on save failure.

* **Tests**
  * Added tests covering object configs, double-encoded object strings, and non-object string configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->