### PR TITLE
fix: refresh app lists after install/uninstall and show installed status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ docs/plans/
 runner.yaml
 
 # Build output
-dist/
+dist/.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ docs/plans/
 runner.yaml
 
 # Build output
-dist/.worktrees/
+dist/
+.worktrees/

--- a/internal/api/app_handler.go
+++ b/internal/api/app_handler.go
@@ -147,13 +147,13 @@ func (s *Server) handleCreateApp(w http.ResponseWriter, r *http.Request) {
 
 // GET /api/apps?listing=listed — public marketplace; otherwise my apps
 func (s *Server) handleListApps(w http.ResponseWriter, r *http.Request) {
+	userID := auth.UserIDFromContext(r.Context())
 	var apps []store.App
 	var err error
 
 	if r.URL.Query().Get("listing") == "listed" {
 		apps, err = s.Store.ListListedApps()
 	} else {
-		userID := auth.UserIDFromContext(r.Context())
 		apps, err = s.Store.ListAppsByOwner(userID)
 	}
 	if err != nil {
@@ -164,8 +164,24 @@ func (s *Server) handleListApps(w http.ResponseWriter, r *http.Request) {
 	if apps == nil {
 		apps = []store.App{}
 	}
+
+	// Annotate with installation status for the current user.
+	installedIDs, err := s.Store.InstalledAppIDs(userID)
+	if err != nil {
+		slog.Warn("failed to load installed app IDs", "user_id", userID, "err", err)
+	}
+
+	type appEntry struct {
+		store.App
+		Installed bool `json:"installed"`
+	}
+	result := make([]appEntry, len(apps))
+	for i, a := range apps {
+		result[i] = appEntry{App: a, Installed: installedIDs[a.ID]}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(apps)
+	json.NewEncoder(w).Encode(result)
 }
 
 // GET /api/apps/{id}

--- a/internal/api/marketplace_handler.go
+++ b/internal/api/marketplace_handler.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/openilink/openilink-hub/internal/auth"
 	"github.com/openilink/openilink-hub/internal/registry"
 	"github.com/openilink/openilink-hub/internal/store"
 )
@@ -77,19 +78,32 @@ func (s *Server) handleMarketplace(w http.ResponseWriter, r *http.Request) {
 
 // GET /api/marketplace/builtin — list all builtin apps
 func (s *Server) handleBuiltinApps(w http.ResponseWriter, r *http.Request) {
+	userID := auth.UserIDFromContext(r.Context())
+
 	apps, err := s.Store.ListMarketplaceApps()
 	if err != nil {
 		jsonError(w, "list failed", http.StatusInternalServerError)
 		return
 	}
-	var result []store.App
+
+	installedIDs, err := s.Store.InstalledAppIDs(userID)
+	if err != nil {
+		slog.Warn("failed to load installed app IDs", "user_id", userID, "err", err)
+	}
+
+	type builtinEntry struct {
+		store.App
+		Installed bool `json:"installed"`
+	}
+
+	var result []builtinEntry
 	for _, a := range apps {
 		if a.Registry == "builtin" {
-			result = append(result, a)
+			result = append(result, builtinEntry{App: a, Installed: installedIDs[a.ID]})
 		}
 	}
 	if result == nil {
-		result = []store.App{}
+		result = []builtinEntry{}
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(result)

--- a/internal/store/app.go
+++ b/internal/store/app.go
@@ -97,6 +97,7 @@ type AppStore interface {
 	UpdateInstallation(id, handle string, config json.RawMessage, scopes json.RawMessage, enabled bool) error
 	SetAppWebhookVerified(id string, verified bool) error
 	UpdateAppWebhookURL(id, webhookURL string) error
+	InstalledAppIDs(userID string) (map[string]bool, error)
 	RegenerateInstallationToken(id string) (string, error)
 	GetInstallationByHandle(botID, handle string) (*AppInstallation, error)
 	DeleteInstallation(id string) error

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -370,6 +370,7 @@ func (s *Store) UpdateMarketplaceApp(string, string, string, string, string, str
 }
 func (s *Store) DeleteApp(string) error                                     { return nil }
 func (s *Store) InstallApp(string, string) (*store.AppInstallation, error)  { return nil, errNotImplemented }
+func (s *Store) InstalledAppIDs(string) (map[string]bool, error) { return nil, nil }
 func (s *Store) ListInstallationsByApp(string) ([]store.AppInstallation, error) { return nil, nil }
 func (s *Store) UpdateInstallation(string, string, json.RawMessage, json.RawMessage, bool) error {
 	return nil

--- a/internal/store/postgres/app.go
+++ b/internal/store/postgres/app.go
@@ -299,6 +299,24 @@ func (db *DB) GetInstallationByToken(token string) (*store.AppInstallation, erro
 	return i, nil
 }
 
+func (db *DB) InstalledAppIDs(userID string) (map[string]bool, error) {
+	rows, err := db.Query(`SELECT DISTINCT i.app_id FROM app_installations i
+		JOIN bots b ON b.id = i.bot_id WHERE b.user_id = $1`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	ids := make(map[string]bool)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids[id] = true
+	}
+	return ids, rows.Err()
+}
+
 func (db *DB) ListInstallationsByApp(appID string) ([]store.AppInstallation, error) {
 	return db.listInstallations("i.app_id = $1", appID)
 }

--- a/internal/store/sqlite/app.go
+++ b/internal/store/sqlite/app.go
@@ -306,6 +306,24 @@ func (db *DB) GetInstallationByToken(token string) (*store.AppInstallation, erro
 	return i, nil
 }
 
+func (db *DB) InstalledAppIDs(userID string) (map[string]bool, error) {
+	rows, err := db.Query(`SELECT DISTINCT i.app_id FROM app_installations i
+		JOIN bots b ON b.id = i.bot_id WHERE b.user_id = ?`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	ids := make(map[string]bool)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids[id] = true
+	}
+	return ids, rows.Err()
+}
+
 func (db *DB) ListInstallationsByApp(appID string) ([]store.AppInstallation, error) {
 	return db.listInstallations("i.app_id = ?", appID)
 }

--- a/web/src/hooks/use-apps.ts
+++ b/web/src/hooks/use-apps.ts
@@ -82,7 +82,7 @@ export function useUninstallApp() {
       api.deleteInstallation(appId, instId),
     onSuccess: (_data, { appId }) => {
       qc.invalidateQueries({ queryKey: queryKeys.apps.installations(appId) });
-      qc.invalidateQueries({ queryKey: ["bots"] });
+      qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
       qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
       qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
       qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });

--- a/web/src/hooks/use-apps.ts
+++ b/web/src/hooks/use-apps.ts
@@ -62,9 +62,30 @@ export function useInstallApp() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ appId, data }: { appId: string; data: any }) => api.installApp(appId, data),
-    onSuccess: (_data, { appId }) => {
+    onSuccess: (_data, { appId, data }) => {
       qc.invalidateQueries({ queryKey: queryKeys.apps.installations(appId) });
       qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
+      if (data?.bot_id) {
+        qc.invalidateQueries({ queryKey: queryKeys.bots.apps(data.bot_id) });
+      }
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+      qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
+    },
+  });
+}
+
+export function useUninstallApp() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ appId, instId }: { appId: string; instId: string }) =>
+      api.deleteInstallation(appId, instId),
+    onSuccess: (_data, { appId }) => {
+      qc.invalidateQueries({ queryKey: queryKeys.apps.installations(appId) });
+      qc.invalidateQueries({ queryKey: ["bots"] });
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+      qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
     },
   });
 }

--- a/web/src/pages/bot-apps-tab.tsx
+++ b/web/src/pages/bot-apps-tab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
@@ -23,7 +23,6 @@ import {
 } from "@/components/ui/dialog";
 
 export function BotAppsTab({ botId }: { botId: string }) {
-  const navigate = useNavigate();
   const { data: installations = [] } = useBotApps(botId);
   const [showInstall, setShowInstall] = useState(false);
   const { toast } = useToast();
@@ -130,7 +129,13 @@ export function BotAppsTab({ botId }: { botId: string }) {
         botId={botId}
         open={showInstall}
         onOpenChange={setShowInstall}
-        onInstalled={() => qc.invalidateQueries({ queryKey: queryKeys.bots.apps(botId) })}
+        onInstalled={() => {
+          qc.invalidateQueries({ queryKey: queryKeys.bots.apps(botId) });
+          qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
+          qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
+          qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+          qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
+        }}
       />
     </div>
   );

--- a/web/src/pages/bot-apps-tab.tsx
+++ b/web/src/pages/bot-apps-tab.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Card, CardContent } from "../components/ui/card";
@@ -7,6 +8,9 @@ import { Badge } from "../components/ui/badge";
 import { api } from "../lib/api";
 import { useToast } from "@/hooks/use-toast";
 import { useConfirm } from "@/components/ui/confirm-dialog";
+import { useBotApps } from "@/hooks/use-bots";
+import { useUninstallApp } from "@/hooks/use-apps";
+import { queryKeys } from "@/lib/query-keys";
 import { Blocks, Plus, Trash2, Loader2, Eye, Zap, Search } from "lucide-react";
 import { AppIcon } from "../components/app-icon";
 import { SCOPE_DESCRIPTIONS } from "../lib/constants";
@@ -20,20 +24,12 @@ import {
 
 export function BotAppsTab({ botId }: { botId: string }) {
   const navigate = useNavigate();
-  const [installations, setInstallations] = useState<any[]>([]);
+  const { data: installations = [] } = useBotApps(botId);
   const [showInstall, setShowInstall] = useState(false);
   const { toast } = useToast();
   const { confirm, ConfirmDialog } = useConfirm();
-
-  async function load() {
-    try {
-      setInstallations((await api.listBotApps(botId)) || []);
-    } catch {}
-  }
-
-  useEffect(() => {
-    load();
-  }, [botId]);
+  const qc = useQueryClient();
+  const uninstallMutation = useUninstallApp();
 
   async function handleUninstall(appId: string, instId: string) {
     const ok = await confirm({
@@ -44,9 +40,8 @@ export function BotAppsTab({ botId }: { botId: string }) {
     });
     if (!ok) return;
     try {
-      await api.deleteInstallation(appId, instId);
+      await uninstallMutation.mutateAsync({ appId, instId });
       toast({ title: "已卸载" });
-      load();
     } catch (e: any) {
       toast({ variant: "destructive", title: "卸载失败", description: e.message });
     }
@@ -55,7 +50,7 @@ export function BotAppsTab({ botId }: { botId: string }) {
   async function handleToggle(inst: any) {
     try {
       await api.updateInstallation(inst.app_id, inst.id, { enabled: !inst.enabled });
-      load();
+      qc.invalidateQueries({ queryKey: queryKeys.bots.apps(botId) });
     } catch {}
   }
 
@@ -135,7 +130,7 @@ export function BotAppsTab({ botId }: { botId: string }) {
         botId={botId}
         open={showInstall}
         onOpenChange={setShowInstall}
-        onInstalled={load}
+        onInstalled={() => qc.invalidateQueries({ queryKey: queryKeys.bots.apps(botId) })}
       />
     </div>
   );

--- a/web/src/pages/bot-detail.tsx
+++ b/web/src/pages/bot-detail.tsx
@@ -77,9 +77,10 @@ export function BotDetailPage() {
   const { data: marketplaceApps = [] } = useMarketplaceApps();
   const { data: availableModels = [] } = useAvailableModels();
 
-  // Derived: listed apps excluding builtins
+  // Derived: listed apps excluding builtins, installed app IDs for this bot
   const builtinSlugs = new Set(builtinApps.map((a: any) => a.slug));
   const listedApps = listedAppsRaw.filter((a: any) => !builtinSlugs.has(a.slug));
+  const installedOnBot = new Set(installations.map((inst: any) => inst.app_id));
   const marketplaceLoading = false; // All queries load in parallel, handled by isLoading above
 
   // Mutations
@@ -481,7 +482,7 @@ export function BotDetailPage() {
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
                         <p className="text-sm font-semibold leading-tight">{app.name}</p>
-                        {app.installed ? (
+                        {installedOnBot.has(app.id) ? (
                           <Badge variant="secondary" className="text-[10px] shrink-0">
                             已安装
                           </Badge>
@@ -496,7 +497,7 @@ export function BotDetailPage() {
                         {parseTools(app.tools).length} 个命令
                       </span>
                     ) : null}
-                    {app.installed ? (
+                    {installedOnBot.has(app.id) ? (
                       <span className="text-[11px] text-muted-foreground/50 shrink-0">已安装</span>
                     ) : (
                       <Button
@@ -534,7 +535,7 @@ export function BotDetailPage() {
                             v{app.version}
                           </Badge>
                         ) : null}
-                        {app.installed ? (
+                        {installedOnBot.has(app.id) ? (
                           <Badge variant="secondary" className="text-[10px] shrink-0">
                             已安装
                           </Badge>
@@ -544,7 +545,7 @@ export function BotDetailPage() {
                         {app.description}
                       </p>
                     </div>
-                    {app.installed ? (
+                    {installedOnBot.has(app.id) ? (
                       <span className="text-[11px] text-muted-foreground/50 shrink-0">已安装</span>
                     ) : (
                       <Button
@@ -582,7 +583,7 @@ export function BotDetailPage() {
                             v{app.version}
                           </Badge>
                         ) : null}
-                        {app.installed ? (
+                        {installedOnBot.has(app.id) ? (
                           <Badge variant="secondary" className="text-[10px] shrink-0">
                             已安装
                           </Badge>

--- a/web/src/pages/bot-detail.tsx
+++ b/web/src/pages/bot-detail.tsx
@@ -479,7 +479,14 @@ export function BotDetailPage() {
                   >
                     <AppIcon icon={app.icon} iconUrl={app.icon_url} size="h-9 w-9" />
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm font-semibold leading-tight">{app.name}</p>
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-semibold leading-tight">{app.name}</p>
+                        {app.installed ? (
+                          <Badge variant="secondary" className="text-[10px] shrink-0">
+                            已安装
+                          </Badge>
+                        ) : null}
+                      </div>
                       <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
                         {app.description}
                       </p>
@@ -489,15 +496,19 @@ export function BotDetailPage() {
                         {parseTools(app.tools).length} 个命令
                       </span>
                     ) : null}
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="shrink-0 gap-1.5"
-                      onClick={() => navigate(`/dashboard/accounts/${id}/install/${app.id}`)}
-                    >
-                      <Download className="h-3.5 w-3.5" />
-                      安装
-                    </Button>
+                    {app.installed ? (
+                      <span className="text-[11px] text-muted-foreground/50 shrink-0">已安装</span>
+                    ) : (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="shrink-0 gap-1.5"
+                        onClick={() => navigate(`/dashboard/accounts/${id}/install/${app.id}`)}
+                      >
+                        <Download className="h-3.5 w-3.5" />
+                        安装
+                      </Button>
+                    )}
                   </div>
                 ))}
               </div>
@@ -523,20 +534,29 @@ export function BotDetailPage() {
                             v{app.version}
                           </Badge>
                         ) : null}
+                        {app.installed ? (
+                          <Badge variant="secondary" className="text-[10px] shrink-0">
+                            已安装
+                          </Badge>
+                        ) : null}
                       </div>
                       <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
                         {app.description}
                       </p>
                     </div>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="shrink-0 gap-1.5"
-                      onClick={() => navigate(`/dashboard/accounts/${id}/install/${app.id}`)}
-                    >
-                      <Download className="h-3.5 w-3.5" />
-                      安装
-                    </Button>
+                    {app.installed ? (
+                      <span className="text-[11px] text-muted-foreground/50 shrink-0">已安装</span>
+                    ) : (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="shrink-0 gap-1.5"
+                        onClick={() => navigate(`/dashboard/accounts/${id}/install/${app.id}`)}
+                      >
+                        <Download className="h-3.5 w-3.5" />
+                        安装
+                      </Button>
+                    )}
                   </div>
                 ))}
               </div>

--- a/web/src/pages/bot-detail.tsx
+++ b/web/src/pages/bot-detail.tsx
@@ -598,7 +598,7 @@ export function BotDetailPage() {
                         {app.author}
                       </span>
                     ) : null}
-                    {app.installed && app.update_available ? (
+                    {installedOnBot.has(app.id) && app.update_available ? (
                       <Button
                         size="sm"
                         variant="outline"
@@ -609,7 +609,7 @@ export function BotDetailPage() {
                         <RefreshCw className="h-3.5 w-3.5" />
                         更新
                       </Button>
-                    ) : app.installed ? (
+                    ) : installedOnBot.has(app.id) ? (
                       <span className="text-[11px] text-muted-foreground/50 shrink-0">已安装</span>
                     ) : (
                       <Button

--- a/web/src/pages/bot-detail.tsx
+++ b/web/src/pages/bot-detail.tsx
@@ -583,7 +583,7 @@ export function BotDetailPage() {
                             v{app.version}
                           </Badge>
                         ) : null}
-                        {installedOnBot.has(app.id) ? (
+                        {app.installed ? (
                           <Badge variant="secondary" className="text-[10px] shrink-0">
                             已安装
                           </Badge>
@@ -598,7 +598,7 @@ export function BotDetailPage() {
                         {app.author}
                       </span>
                     ) : null}
-                    {installedOnBot.has(app.id) && app.update_available ? (
+                    {app.installed && app.update_available ? (
                       <Button
                         size="sm"
                         variant="outline"
@@ -609,7 +609,7 @@ export function BotDetailPage() {
                         <RefreshCw className="h-3.5 w-3.5" />
                         更新
                       </Button>
-                    ) : installedOnBot.has(app.id) ? (
+                    ) : app.installed ? (
                       <span className="text-[11px] text-muted-foreground/50 shrink-0">已安装</span>
                     ) : (
                       <Button

--- a/web/src/pages/install-app.tsx
+++ b/web/src/pages/install-app.tsx
@@ -25,6 +25,13 @@ export function InstallAppPage() {
   const navigate = useNavigate();
   const { toast } = useToast();
   const qc = useQueryClient();
+  const invalidateAppQueries = () => {
+    qc.invalidateQueries({ queryKey: queryKeys.bots.apps(botId!) });
+    qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
+    qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
+    qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+    qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
+  };
   const { data: app, isLoading: appLoading } = useApp(appId!);
   const { data: allBots = [] } = useBots();
   const bot = allBots.find((b: any) => b.id === botId);
@@ -53,6 +60,7 @@ export function InstallAppPage() {
       if (event.data?.type === "oauth_complete") {
         setWaitingForOAuth(false);
         if (oauthPopup && !oauthPopup.closed) oauthPopup.close();
+        invalidateAppQueries();
         toast({ title: "安装成功" });
         navigate(`/dashboard/accounts/${botId}`);
       }
@@ -66,6 +74,7 @@ export function InstallAppPage() {
           clearInterval(interval);
           setWaitingForOAuth(false);
           if (oauthPopup && !oauthPopup.closed) oauthPopup.close();
+          invalidateAppQueries();
           toast({ title: "安装成功" });
           navigate(`/dashboard/accounts/${botId}`);
         }
@@ -111,11 +120,7 @@ export function InstallAppPage() {
       }
 
       toast({ title: "安装成功" });
-      qc.invalidateQueries({ queryKey: queryKeys.bots.apps(botId!) });
-      qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
-      qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
+      invalidateAppQueries();
       navigate(`/dashboard/accounts/${botId}/apps/${installationId}`);
     } catch (e: any) {
       toast({ variant: "destructive", title: "安装失败", description: e.message });

--- a/web/src/pages/install-app.tsx
+++ b/web/src/pages/install-app.tsx
@@ -7,10 +7,12 @@ import { Input } from "../components/ui/input";
 import { Card, CardContent } from "../components/ui/card";
 import { Skeleton } from "../components/ui/skeleton";
 import { Label } from "../components/ui/label";
+import { useQueryClient } from "@tanstack/react-query";
 import { api, botDisplayName } from "../lib/api";
 import { useApp } from "@/hooks/use-apps";
 import { useBots } from "@/hooks/use-bots";
 import { useToast } from "@/hooks/use-toast";
+import { queryKeys } from "@/lib/query-keys";
 import { AppIcon } from "../components/app-icon";
 import { SCOPE_DESCRIPTIONS, EVENT_TYPES } from "../lib/constants";
 import { ToolsDisplay, parseTools } from "../components/tools-display";
@@ -22,6 +24,7 @@ export function InstallAppPage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { toast } = useToast();
+  const qc = useQueryClient();
   const { data: app, isLoading: appLoading } = useApp(appId!);
   const { data: allBots = [] } = useBots();
   const bot = allBots.find((b: any) => b.id === botId);
@@ -108,6 +111,11 @@ export function InstallAppPage() {
       }
 
       toast({ title: "安装成功" });
+      qc.invalidateQueries({ queryKey: queryKeys.bots.apps(botId!) });
+      qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+      qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
       navigate(`/dashboard/accounts/${botId}/apps/${installationId}`);
     } catch (e: any) {
       toast({ variant: "destructive", title: "安装失败", description: e.message });


### PR DESCRIPTION
## Summary

Fixes #200 (issues 3, 4, 5):

- **Issue 3** — 卸载应用后列表不刷新：`BotAppsTab` 从手动 `useState`/`useEffect` 重构为 React Query，卸载使用新增的 `useUninstallApp` mutation，自动触发 cache invalidation
- **Issue 4** — 安装应用后列表不刷新：修复 `useInstallApp` 的 invalidation keys（加上 `bots.apps`、marketplace、builtin），`InstallAppPage` 安装成功后也执行 invalidation
- **Issue 5** — 推荐/内置应用不显示「已安装」：后端新增 `InstalledAppIDs(userID)` store 方法，`/api/apps` 和 `/api/marketplace/builtin` 响应中加入 `installed` 字段，前端对应显示「已安装」badge

## Changes

**Backend (4 files):**
- `store/app.go` — 新增 `InstalledAppIDs` 接口方法
- `store/sqlite/app.go` + `store/postgres/app.go` — 实现 `SELECT DISTINCT app_id FROM app_installations JOIN bots WHERE user_id = ?`
- `api/app_handler.go` — `handleListApps` 返回 `installed` 字段
- `api/marketplace_handler.go` — `handleBuiltinApps` 返回 `installed` 字段

**Frontend (4 files):**
- `hooks/use-apps.ts` — 修复 `useInstallApp` invalidation，新增 `useUninstallApp` mutation
- `pages/bot-apps-tab.tsx` — 使用 React Query 替代手动状态管理
- `pages/install-app.tsx` — 安装成功后 invalidate 相关 queries
- `pages/bot-detail.tsx` — 内置/推荐应用显示「已安装」badge

## Test plan

- [ ] 安装应用后，返回账号详情页，已安装列表实时更新
- [ ] 卸载应用后，列表实时刷新，无需手动刷新
- [ ] 内置应用区域：已安装的显示「已安装」badge，安装按钮变为文字提示
- [ ] 推荐应用区域：同上
- [ ] 远程市场区域：已有的「已安装」逻辑不受影响
- [ ] 多 bot 场景：在 bot A 安装的应用，bot B 的页面也能正确显示安装状态

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps now show per-user "Installed" status across marketplace, built-ins, recommended, and bot-specific views.
  * Added uninstall flow with integrated post-uninstall updates.

* **Improvements**
  * Cache invalidation ensures installation state updates propagate immediately across bot pages, marketplace, built-ins, and app listings.
  * UI now shows installed/updated badges and conditional install/update actions based on per-bot install state.

* **Chores**
  * Refined .gitignore rule for build output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->