### PR TITLE
feat: forward file messages to apps with accessible media URLs

### DIFF
--- a/internal/api/media_handler.go
+++ b/internal/api/media_handler.go
@@ -16,6 +16,7 @@ import (
 // Auth:
 //   - Channel API key (?key=xxx): channel must belong to the bot
 //   - Session cookie + bot query param: user must own the bot
+//   - Bearer app token: app installation must have a connected bot
 func (s *Server) handleChannelMedia(w http.ResponseWriter, r *http.Request) {
 	eqp := r.URL.Query().Get("eqp")
 	aes := r.URL.Query().Get("aes")
@@ -37,24 +38,39 @@ func (s *Server) handleChannelMedia(w http.ResponseWriter, r *http.Request) {
 
 	// Auth path 2: session cookie + explicit bot ID
 	botID := r.URL.Query().Get("bot")
-	if botID == "" {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
-	}
-	if cookie, err := r.Cookie("session"); err == nil {
-		if uid, err := auth.ValidateSession(s.Store, cookie.Value); err == nil && uid != "" {
-			b, err := s.Store.GetBot(botID)
-			if err != nil || b.UserID != uid {
-				http.Error(w, "unauthorized", http.StatusUnauthorized)
+	if botID != "" {
+		if cookie, err := r.Cookie("session"); err == nil {
+			if uid, err := auth.ValidateSession(s.Store, cookie.Value); err == nil && uid != "" {
+				b, err := s.Store.GetBot(botID)
+				if err != nil || b.UserID != uid {
+					http.Error(w, "unauthorized", http.StatusUnauthorized)
+					return
+				}
+				inst, ok := s.BotManager.GetInstance(botID)
+				if !ok {
+					http.Error(w, "bot not connected", http.StatusServiceUnavailable)
+					return
+				}
+				s.serveChannelMedia(w, r, inst, eqp, aes)
 				return
 			}
-			inst, ok := s.BotManager.GetInstance(botID)
-			if !ok {
+		}
+	}
+
+	// Auth path 3: Bearer app token (for apps like OpenClaw)
+	if authHeader := r.Header.Get("Authorization"); strings.HasPrefix(authHeader, "Bearer ") {
+		token := strings.TrimPrefix(authHeader, "Bearer ")
+		if token != "" {
+			inst, err := s.Store.GetInstallationByToken(token)
+			if err == nil && inst != nil {
+				botInst, ok := s.BotManager.GetInstance(inst.BotID)
+				if ok {
+					s.serveChannelMedia(w, r, botInst, eqp, aes)
+					return
+				}
 				http.Error(w, "bot not connected", http.StatusServiceUnavailable)
 				return
 			}
-			s.serveChannelMedia(w, r, inst, eqp, aes)
-			return
 		}
 	}
 
@@ -90,6 +106,7 @@ func (s *Server) serveChannelMedia(w http.ResponseWriter, r *http.Request, inst 
 // Auth:
 //   - Session cookie: user must own the bot
 //   - Channel API key (?key=xxx): channel must belong to the bot
+//   - Bearer app token: app installation must belong to the bot
 func (s *Server) handleMediaProxy(w http.ResponseWriter, r *http.Request) {
 	if s.ObjectStore == nil {
 		http.Error(w, "storage not configured", http.StatusNotFound)
@@ -123,6 +140,17 @@ func (s *Server) handleMediaProxy(w http.ResponseWriter, r *http.Request) {
 	if !authed {
 		if ch, _ := s.authenticateChannel(r); ch != nil && ch.BotID == botID {
 			authed = true
+		}
+	}
+	// Auth: Bearer app token → check installation belongs to this bot
+	if !authed {
+		if authHeader := r.Header.Get("Authorization"); strings.HasPrefix(authHeader, "Bearer ") {
+			token := strings.TrimPrefix(authHeader, "Bearer ")
+			if token != "" {
+				if inst, err := s.Store.GetInstallationByToken(token); err == nil && inst != nil && inst.BotID == botID {
+					authed = true
+				}
+			}
 		}
 	}
 	if !authed {

--- a/internal/api/media_handler.go
+++ b/internal/api/media_handler.go
@@ -1,12 +1,14 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
 	"github.com/openilink/openilink-hub/internal/auth"
 	"github.com/openilink/openilink-hub/internal/bot"
 	"github.com/openilink/openilink-hub/internal/provider"
+	"github.com/openilink/openilink-hub/internal/store"
 )
 
 // GET /api/v1/channels/media?bot=xxx&eqp=xxx&aes=xxx
@@ -62,7 +64,11 @@ func (s *Server) handleChannelMedia(w http.ResponseWriter, r *http.Request) {
 		token := strings.TrimPrefix(authHeader, "Bearer ")
 		if token != "" {
 			inst, err := s.Store.GetInstallationByToken(token)
-			if err == nil && inst != nil {
+			if err == nil && inst != nil && inst.Enabled && installationHasScope(inst, "message:read") {
+				if botID != "" && inst.BotID != botID {
+					http.Error(w, "unauthorized", http.StatusUnauthorized)
+					return
+				}
 				botInst, ok := s.BotManager.GetInstance(inst.BotID)
 				if ok {
 					s.serveChannelMedia(w, r, botInst, eqp, aes)
@@ -147,7 +153,7 @@ func (s *Server) handleMediaProxy(w http.ResponseWriter, r *http.Request) {
 		if authHeader := r.Header.Get("Authorization"); strings.HasPrefix(authHeader, "Bearer ") {
 			token := strings.TrimPrefix(authHeader, "Bearer ")
 			if token != "" {
-				if inst, err := s.Store.GetInstallationByToken(token); err == nil && inst != nil && inst.BotID == botID {
+				if inst, err := s.Store.GetInstallationByToken(token); err == nil && inst != nil && inst.Enabled && inst.BotID == botID && installationHasScope(inst, "message:read") {
 					authed = true
 				}
 			}
@@ -176,4 +182,21 @@ func (s *Server) handleMediaProxy(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Cache-Control", "private, max-age=86400")
 	w.Write(data)
+}
+
+// installationHasScope checks if the installation has the given scope granted.
+func installationHasScope(inst *store.AppInstallation, scope string) bool {
+	if len(inst.Scopes) == 0 || string(inst.Scopes) == "[]" || string(inst.Scopes) == "null" {
+		return false
+	}
+	var scopes []string
+	if err := json.Unmarshal(inst.Scopes, &scopes); err != nil {
+		return false
+	}
+	for _, s := range scopes {
+		if s == scope {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/media_handler_test.go
+++ b/internal/api/media_handler_test.go
@@ -1,0 +1,276 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/openilink/openilink-hub/internal/bot"
+	"github.com/openilink/openilink-hub/internal/config"
+	"github.com/openilink/openilink-hub/internal/provider"
+	"github.com/openilink/openilink-hub/internal/store"
+	"github.com/openilink/openilink-hub/internal/store/sqlite"
+)
+
+// ---------------------------------------------------------------------------
+// mock provider (minimal, for media handler tests)
+// ---------------------------------------------------------------------------
+
+type mockProvider struct{}
+
+func (m *mockProvider) Name() string                          { return "mock" }
+func (m *mockProvider) Start(context.Context, provider.StartOptions) error { return nil }
+func (m *mockProvider) Stop()                                 {}
+func (m *mockProvider) Send(context.Context, provider.OutboundMessage) (string, error) {
+	return "", nil
+}
+func (m *mockProvider) SendTyping(context.Context, string, string, bool) error { return nil }
+func (m *mockProvider) GetConfig(context.Context, string, string) (*provider.BotConfig, error) {
+	return nil, nil
+}
+func (m *mockProvider) DownloadMedia(_ context.Context, _ *provider.Media) ([]byte, error) {
+	// Return a tiny PNG so Content-Type detection works
+	return []byte("\x89PNG\r\n\x1a\n" + "fake-image-data"), nil
+}
+func (m *mockProvider) DownloadVoice(context.Context, *provider.Media, int) ([]byte, error) {
+	return nil, nil
+}
+func (m *mockProvider) Status() string { return "connected" }
+
+// ---------------------------------------------------------------------------
+// mock object store
+// ---------------------------------------------------------------------------
+
+type mockObjectStore struct {
+	mu   sync.Mutex
+	data map[string][]byte
+}
+
+func newMockObjectStore() *mockObjectStore {
+	return &mockObjectStore{data: make(map[string][]byte)}
+}
+
+func (m *mockObjectStore) Put(_ context.Context, key, _ string, data []byte) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[key] = data
+	return key, nil
+}
+
+func (m *mockObjectStore) Get(_ context.Context, key string) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d, ok := m.data[key]
+	if !ok {
+		return nil, io.EOF
+	}
+	return d, nil
+}
+
+func (m *mockObjectStore) URL(key string) string { return "/media/" + key }
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// setupMediaTestEnv creates a test environment with BotManager and a running
+// mock bot instance so the media handlers can resolve the bot.
+func setupMediaTestEnv(t *testing.T) (*httptest.Server, store.Store, *store.Bot, *store.AppInstallation) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := sqlite.Open(dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	u, err := s.CreateUserFull("testadmin", "", "Test Admin", "hashed", store.RoleAdmin)
+	if err != nil {
+		t.Fatalf("CreateUserFull: %v", err)
+	}
+	_ = s.UpdateUserStatus(u.ID, store.StatusActive)
+
+	// Create a bot.
+	b, err := s.CreateBot(u.ID, "mediabot", "mock", "", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("CreateBot: %v", err)
+	}
+
+	// Register mock provider and create a Manager with a running instance.
+	provider.Register("mock", func() provider.Provider { return &mockProvider{} })
+	mgr := bot.NewManager(s, nil, nil, nil, "http://localhost")
+	if err := mgr.StartBot(context.Background(), b); err != nil {
+		t.Fatalf("StartBot: %v", err)
+	}
+	t.Cleanup(mgr.StopAll)
+
+	// Create an app and install it on the bot.
+	scopesJSON, _ := json.Marshal([]string{"messages:read"})
+	app, err := s.CreateApp(&store.App{
+		OwnerID: u.ID,
+		Name:    "MediaTestApp",
+		Slug:    "media-test-app",
+		Scopes:  scopesJSON,
+	})
+	if err != nil {
+		t.Fatalf("CreateApp: %v", err)
+	}
+	inst, err := s.InstallApp(app.ID, b.ID)
+	if err != nil {
+		t.Fatalf("InstallApp: %v", err)
+	}
+
+	// Set up object store with a test file.
+	objStore := newMockObjectStore()
+	_, _ = objStore.Put(context.Background(), b.ID+"/2024-01-01/test.png", "image/png",
+		[]byte("\x89PNG\r\n\x1a\n"+"fake-image-data"))
+
+	srv := &Server{
+		Store:       s,
+		BotManager:  mgr,
+		Config:      &config.Config{RPOrigin: "http://localhost"},
+		OAuthStates: newOAuthStateStore(),
+		ObjectStore: objStore,
+	}
+
+	handler := srv.Handler()
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	return ts, s, b, inst
+}
+
+// ---------------------------------------------------------------------------
+// Tests: CDN media proxy (handleChannelMedia)
+// ---------------------------------------------------------------------------
+
+func TestChannelMedia_BearerAppToken(t *testing.T) {
+	ts, _, _, inst := setupMediaTestEnv(t)
+
+	resp, err := doMediaReq(t, ts, "/api/v1/channels/media?eqp=test&aes=test123",
+		"Bearer "+inst.AppToken)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// The mock provider returns data, so we expect 200 (not 401).
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+func TestChannelMedia_InvalidBearer(t *testing.T) {
+	ts, _, _, _ := setupMediaTestEnv(t)
+
+	resp, err := doMediaReq(t, ts, "/api/v1/channels/media?eqp=test&aes=test123",
+		"Bearer invalid-token-xxx")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401, got %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+func TestChannelMedia_NoAuth(t *testing.T) {
+	ts, _, _, _ := setupMediaTestEnv(t)
+
+	resp, err := doMediaReq(t, ts, "/api/v1/channels/media?eqp=test&aes=test123", "")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401, got %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Storage media proxy (handleMediaProxy)
+// ---------------------------------------------------------------------------
+
+func TestMediaProxy_BearerAppToken(t *testing.T) {
+	ts, _, b, inst := setupMediaTestEnv(t)
+
+	resp, err := doMediaReq(t, ts, "/api/v1/media/"+b.ID+"/2024-01-01/test.png",
+		"Bearer "+inst.AppToken)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+func TestMediaProxy_InvalidBearer(t *testing.T) {
+	ts, _, b, _ := setupMediaTestEnv(t)
+
+	resp, err := doMediaReq(t, ts, "/api/v1/media/"+b.ID+"/2024-01-01/test.png",
+		"Bearer invalid-token-xxx")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401, got %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+func TestMediaProxy_BearerWrongBot(t *testing.T) {
+	ts, s, _, inst := setupMediaTestEnv(t)
+
+	// Create a second bot that the installation does NOT belong to.
+	u, _ := s.CreateUserFull("other", "", "Other", "hashed", store.RoleAdmin)
+	_ = s.UpdateUserStatus(u.ID, store.StatusActive)
+	b2, err := s.CreateBot(u.ID, "otherbot", "mock", "", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("CreateBot: %v", err)
+	}
+
+	// Request media for b2 using inst's token (which belongs to a different bot).
+	resp, err := doMediaReq(t, ts, "/api/v1/media/"+b2.ID+"/2024-01-01/test.png",
+		"Bearer "+inst.AppToken)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401, got %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helper
+// ---------------------------------------------------------------------------
+
+func doMediaReq(t *testing.T, ts *httptest.Server, path, authHeader string) (*http.Response, error) {
+	t.Helper()
+	req, err := http.NewRequest("GET", ts.URL+path, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	return http.DefaultClient.Do(req)
+}

--- a/internal/api/media_handler_test.go
+++ b/internal/api/media_handler_test.go
@@ -111,7 +111,7 @@ func setupMediaTestEnv(t *testing.T) (*httptest.Server, store.Store, *store.Bot,
 	t.Cleanup(mgr.StopAll)
 
 	// Create an app and install it on the bot.
-	scopesJSON, _ := json.Marshal([]string{"messages:read"})
+	scopesJSON, _ := json.Marshal([]string{"message:read"})
 	app, err := s.CreateApp(&store.App{
 		OwnerID: u.ID,
 		Name:    "MediaTestApp",
@@ -124,6 +124,15 @@ func setupMediaTestEnv(t *testing.T) (*httptest.Server, store.Store, *store.Bot,
 	inst, err := s.InstallApp(app.ID, b.ID)
 	if err != nil {
 		t.Fatalf("InstallApp: %v", err)
+	}
+	// Grant message:read scope so Bearer auth passes scope check.
+	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), scopesJSON, true); err != nil {
+		t.Fatalf("UpdateInstallation: %v", err)
+	}
+	// Re-read to pick up updated scopes.
+	inst, err = s.GetInstallation(inst.ID)
+	if err != nil {
+		t.Fatalf("GetInstallation: %v", err)
 	}
 
 	// Set up object store with a test file.
@@ -256,6 +265,96 @@ func TestMediaProxy_BearerWrongBot(t *testing.T) {
 	if resp.StatusCode != http.StatusUnauthorized {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected 401, got %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: disabled installation and missing scope
+// ---------------------------------------------------------------------------
+
+func TestChannelMedia_BearerDisabledInstallation(t *testing.T) {
+	ts, s, _, inst := setupMediaTestEnv(t)
+
+	// Disable the installation.
+	scopesJSON, _ := json.Marshal([]string{"message:read"})
+	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), scopesJSON, false); err != nil {
+		t.Fatalf("UpdateInstallation: %v", err)
+	}
+
+	resp, err := doMediaReq(t, ts, "/api/v1/channels/media?eqp=test&aes=test123",
+		"Bearer "+inst.AppToken)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401 for disabled installation, got %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+func TestChannelMedia_BearerNoScope(t *testing.T) {
+	ts, s, _, inst := setupMediaTestEnv(t)
+
+	// Clear scopes on the installation.
+	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), json.RawMessage("[]"), true); err != nil {
+		t.Fatalf("UpdateInstallation: %v", err)
+	}
+
+	resp, err := doMediaReq(t, ts, "/api/v1/channels/media?eqp=test&aes=test123",
+		"Bearer "+inst.AppToken)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401 for missing scope, got %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+func TestMediaProxy_BearerDisabledInstallation(t *testing.T) {
+	ts, s, b, inst := setupMediaTestEnv(t)
+
+	// Disable the installation.
+	scopesJSON, _ := json.Marshal([]string{"message:read"})
+	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), scopesJSON, false); err != nil {
+		t.Fatalf("UpdateInstallation: %v", err)
+	}
+
+	resp, err := doMediaReq(t, ts, "/api/v1/media/"+b.ID+"/2024-01-01/test.png",
+		"Bearer "+inst.AppToken)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401 for disabled installation, got %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+func TestMediaProxy_BearerNoScope(t *testing.T) {
+	ts, s, b, inst := setupMediaTestEnv(t)
+
+	// Clear scopes on the installation.
+	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), json.RawMessage("[]"), true); err != nil {
+		t.Fatalf("UpdateInstallation: %v", err)
+	}
+
+	resp, err := doMediaReq(t, ts, "/api/v1/media/"+b.ID+"/2024-01-01/test.png",
+		"Bearer "+inst.AppToken)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401 for missing scope, got %d: %s", resp.StatusCode, string(body))
 	}
 }
 

--- a/internal/bot/app_dispatch.go
+++ b/internal/bot/app_dispatch.go
@@ -626,6 +626,7 @@ func detectOutboundExt(filename, msgType string) string {
 // resolveMediaURLs returns a copy of items with raw CDN URLs replaced by
 // Hub proxy URLs so external apps can fetch media. Items without EQP
 // (already processed or text-only) are left unchanged.
+// RefMsg is handled one level deep, which matches WeChat's quoting model.
 func resolveMediaURLs(items []relay.MessageItem, baseURL, botDBID string) []relay.MessageItem {
 	out := make([]relay.MessageItem, len(items))
 	copy(out, items)

--- a/internal/bot/app_dispatch.go
+++ b/internal/bot/app_dispatch.go
@@ -54,13 +54,15 @@ func (m *Manager) deliverToApps(inst *Instance, msg provider.InboundMessage, p p
 		return
 	}
 
+	resolvedItems := resolveMediaURLs(p.relayItems, m.baseURL, inst.DBID)
+
 	event := appdelivery.NewEvent(eventType, map[string]any{
 		"message_id": msg.ExternalID,
 		"sender":     map[string]any{"id": msg.Sender, "role": "user"},
 		"group":      groupInfo(msg),
 		"content":    content,
 		"msg_type":   p.msgType,
-		"items":      p.relayItems,
+		"items":      resolvedItems,
 	})
 	event.TraceID = tracer.TraceID()
 

--- a/internal/bot/app_dispatch.go
+++ b/internal/bot/app_dispatch.go
@@ -632,22 +632,14 @@ func resolveMediaURLs(items []relay.MessageItem, baseURL, botDBID string) []rela
 			continue
 		}
 		m := *out[i].Media
-		m.URL = fmt.Sprintf("%s/api/v1/channels/media?bot=%s&eqp=%s&aes=%s&ct=%s",
-			baseURL, botDBID, m.EQP, m.AESKey, url.QueryEscape(mediaProxyContentType(out[i].Type)))
+		q := url.Values{}
+		q.Set("bot", botDBID)
+		q.Set("eqp", m.EQP)
+		q.Set("aes", m.AESKey)
+		q.Set("ct", mediaContentType(out[i].Type))
+		m.URL = fmt.Sprintf("%s/api/v1/channels/media?%s", baseURL, q.Encode())
 		out[i].Media = &m
 	}
 	return out
 }
 
-func mediaProxyContentType(itemType string) string {
-	switch itemType {
-	case "image":
-		return "image/jpeg"
-	case "voice":
-		return "audio/wav"
-	case "video":
-		return "video/mp4"
-	default:
-		return "application/octet-stream"
-	}
-}

--- a/internal/bot/app_dispatch.go
+++ b/internal/bot/app_dispatch.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 	appdelivery "github.com/openilink/openilink-hub/internal/app"
 	"github.com/openilink/openilink-hub/internal/builtin"
 	"github.com/openilink/openilink-hub/internal/provider"
+	"github.com/openilink/openilink-hub/internal/relay"
 	"github.com/openilink/openilink-hub/internal/store"
 )
 
@@ -616,5 +618,36 @@ func detectOutboundExt(filename, msgType string) string {
 		return ".wav"
 	default:
 		return ""
+	}
+}
+
+// resolveMediaURLs returns a copy of items with raw CDN URLs replaced by
+// Hub proxy URLs so external apps can fetch media. Items without EQP
+// (already processed or text-only) are left unchanged.
+func resolveMediaURLs(items []relay.MessageItem, baseURL, botDBID string) []relay.MessageItem {
+	out := make([]relay.MessageItem, len(items))
+	copy(out, items)
+	for i := range out {
+		if out[i].Media == nil || out[i].Media.EQP == "" {
+			continue
+		}
+		m := *out[i].Media
+		m.URL = fmt.Sprintf("%s/api/v1/channels/media?bot=%s&eqp=%s&aes=%s&ct=%s",
+			baseURL, botDBID, m.EQP, m.AESKey, url.QueryEscape(mediaProxyContentType(out[i].Type)))
+		out[i].Media = &m
+	}
+	return out
+}
+
+func mediaProxyContentType(itemType string) string {
+	switch itemType {
+	case "image":
+		return "image/jpeg"
+	case "voice":
+		return "audio/wav"
+	case "video":
+		return "video/mp4"
+	default:
+		return "application/octet-stream"
 	}
 }

--- a/internal/bot/app_dispatch.go
+++ b/internal/bot/app_dispatch.go
@@ -640,6 +640,8 @@ func resolveMediaURLs(items []relay.MessageItem, baseURL, botDBID string) []rela
 		q.Set("aes", m.AESKey)
 		q.Set("ct", mediaContentType(out[i].Type))
 		m.URL = fmt.Sprintf("%s/api/v1/channels/media?%s", baseURL, q.Encode())
+		m.EQP = ""
+		m.AESKey = ""
 		out[i].Media = &m
 	}
 	return out

--- a/internal/bot/app_dispatch.go
+++ b/internal/bot/app_dispatch.go
@@ -630,20 +630,29 @@ func resolveMediaURLs(items []relay.MessageItem, baseURL, botDBID string) []rela
 	out := make([]relay.MessageItem, len(items))
 	copy(out, items)
 	for i := range out {
-		if out[i].Media == nil || out[i].Media.EQP == "" {
-			continue
+		resolveItemMedia(&out[i], baseURL, botDBID)
+		if out[i].RefMsg != nil {
+			ref := *out[i].RefMsg
+			resolveItemMedia(&ref.Item, baseURL, botDBID)
+			out[i].RefMsg = &ref
 		}
-		m := *out[i].Media
-		q := url.Values{}
-		q.Set("bot", botDBID)
-		q.Set("eqp", m.EQP)
-		q.Set("aes", m.AESKey)
-		q.Set("ct", mediaContentType(out[i].Type))
-		m.URL = fmt.Sprintf("%s/api/v1/channels/media?%s", baseURL, q.Encode())
-		m.EQP = ""
-		m.AESKey = ""
-		out[i].Media = &m
 	}
 	return out
+}
+
+func resolveItemMedia(item *relay.MessageItem, baseURL, botDBID string) {
+	if item.Media == nil || item.Media.EQP == "" {
+		return
+	}
+	m := *item.Media
+	q := url.Values{}
+	q.Set("bot", botDBID)
+	q.Set("eqp", m.EQP)
+	q.Set("aes", m.AESKey)
+	q.Set("ct", mediaContentType(item.Type))
+	m.URL = fmt.Sprintf("%s/api/v1/channels/media?%s", baseURL, q.Encode())
+	m.EQP = ""
+	m.AESKey = ""
+	item.Media = &m
 }
 

--- a/internal/bot/app_dispatch_test.go
+++ b/internal/bot/app_dispatch_test.go
@@ -40,7 +40,7 @@ func TestResolveMediaURLs(t *testing.T) {
 		t.Error("text item should have no media")
 	}
 
-	want := "https://hub.example.com/api/v1/channels/media?bot=bot-123&eqp=eqp-file-param&aes=abc123&ct=application%2Foctet-stream"
+	want := "https://hub.example.com/api/v1/channels/media?aes=abc123&bot=bot-123&ct=application%2Foctet-stream&eqp=eqp-file-param"
 	if result[1].Media.URL != want {
 		t.Errorf("file URL = %q, want %q", result[1].Media.URL, want)
 	}
@@ -48,7 +48,7 @@ func TestResolveMediaURLs(t *testing.T) {
 		t.Error("file size should be preserved")
 	}
 
-	wantImg := "https://hub.example.com/api/v1/channels/media?bot=bot-123&eqp=eqp-image-param&aes=def456&ct=image%2Fjpeg"
+	wantImg := "https://hub.example.com/api/v1/channels/media?aes=def456&bot=bot-123&ct=image%2Fjpeg&eqp=eqp-image-param"
 	if result[2].Media.URL != wantImg {
 		t.Errorf("image URL = %q, want %q", result[2].Media.URL, wantImg)
 	}

--- a/internal/bot/app_dispatch_test.go
+++ b/internal/bot/app_dispatch_test.go
@@ -1,0 +1,88 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/openilink/openilink-hub/internal/relay"
+)
+
+func TestResolveMediaURLs(t *testing.T) {
+	baseURL := "https://hub.example.com"
+	botDBID := "bot-123"
+
+	items := []relay.MessageItem{
+		{Type: "text", Text: "hello"},
+		{
+			Type:     "file",
+			FileName: "doc.pdf",
+			Media: &relay.Media{
+				URL:       "https://wechat-cdn.example.com/encrypted-file",
+				EQP:       "eqp-file-param",
+				AESKey:    "abc123",
+				FileSize:  1024,
+				MediaType: "file",
+			},
+		},
+		{
+			Type: "image",
+			Media: &relay.Media{
+				URL:       "https://wechat-cdn.example.com/encrypted-image",
+				EQP:       "eqp-image-param",
+				AESKey:    "def456",
+				MediaType: "image",
+			},
+		},
+	}
+
+	result := resolveMediaURLs(items, baseURL, botDBID)
+
+	if result[0].Media != nil {
+		t.Error("text item should have no media")
+	}
+
+	want := "https://hub.example.com/api/v1/channels/media?bot=bot-123&eqp=eqp-file-param&aes=abc123&ct=application%2Foctet-stream"
+	if result[1].Media.URL != want {
+		t.Errorf("file URL = %q, want %q", result[1].Media.URL, want)
+	}
+	if result[1].Media.FileSize != 1024 {
+		t.Error("file size should be preserved")
+	}
+
+	wantImg := "https://hub.example.com/api/v1/channels/media?bot=bot-123&eqp=eqp-image-param&aes=def456&ct=image%2Fjpeg"
+	if result[2].Media.URL != wantImg {
+		t.Errorf("image URL = %q, want %q", result[2].Media.URL, wantImg)
+	}
+
+	// Original not mutated
+	if items[1].Media.URL != "https://wechat-cdn.example.com/encrypted-file" {
+		t.Error("original items should not be mutated")
+	}
+}
+
+func TestResolveMediaURLs_NoMedia(t *testing.T) {
+	items := []relay.MessageItem{
+		{Type: "text", Text: "hello"},
+	}
+	result := resolveMediaURLs(items, "https://hub.example.com", "bot-123")
+	if len(result) != 1 || result[0].Text != "hello" {
+		t.Error("text-only items should pass through unchanged")
+	}
+}
+
+func TestResolveMediaURLs_AlreadyStorageURL(t *testing.T) {
+	items := []relay.MessageItem{
+		{
+			Type: "image",
+			Media: &relay.Media{
+				URL:       "https://storage.example.com/bot-123/img.jpg",
+				EQP:       "",
+				AESKey:    "",
+				MediaType: "image",
+			},
+		},
+	}
+	result := resolveMediaURLs(items, "https://hub.example.com", "bot-123")
+	if result[0].Media.URL != "https://storage.example.com/bot-123/img.jpg" {
+		t.Error("items without EQP should keep original URL")
+	}
+}

--- a/internal/bot/app_dispatch_test.go
+++ b/internal/bot/app_dispatch_test.go
@@ -47,10 +47,22 @@ func TestResolveMediaURLs(t *testing.T) {
 	if result[1].Media.FileSize != 1024 {
 		t.Error("file size should be preserved")
 	}
+	if result[1].Media.EQP != "" {
+		t.Errorf("file EQP should be cleared, got %q", result[1].Media.EQP)
+	}
+	if result[1].Media.AESKey != "" {
+		t.Errorf("file AESKey should be cleared, got %q", result[1].Media.AESKey)
+	}
 
 	wantImg := "https://hub.example.com/api/v1/channels/media?aes=def456&bot=bot-123&ct=image%2Fjpeg&eqp=eqp-image-param"
 	if result[2].Media.URL != wantImg {
 		t.Errorf("image URL = %q, want %q", result[2].Media.URL, wantImg)
+	}
+	if result[2].Media.EQP != "" {
+		t.Errorf("image EQP should be cleared, got %q", result[2].Media.EQP)
+	}
+	if result[2].Media.AESKey != "" {
+		t.Errorf("image AESKey should be cleared, got %q", result[2].Media.AESKey)
 	}
 
 	// Original not mutated

--- a/internal/bot/app_dispatch_test.go
+++ b/internal/bot/app_dispatch_test.go
@@ -81,6 +81,55 @@ func TestResolveMediaURLs_NoMedia(t *testing.T) {
 	}
 }
 
+func TestResolveMediaURLs_RefMsg(t *testing.T) {
+	baseURL := "https://hub.example.com"
+	botDBID := "bot-123"
+
+	items := []relay.MessageItem{
+		{
+			Type: "text",
+			Text: "quoting an image",
+			RefMsg: &relay.RefMsg{
+				Title: "original sender",
+				Item: relay.MessageItem{
+					Type: "image",
+					Media: &relay.Media{
+						URL:       "https://wechat-cdn.example.com/ref-image",
+						EQP:       "eqp-ref-param",
+						AESKey:    "refkey",
+						MediaType: "image",
+					},
+				},
+			},
+		},
+	}
+
+	result := resolveMediaURLs(items, baseURL, botDBID)
+
+	ref := result[0].RefMsg
+	if ref == nil {
+		t.Fatal("RefMsg should be present")
+	}
+	if ref.Item.Media == nil {
+		t.Fatal("RefMsg item media should be present")
+	}
+	if ref.Item.Media.EQP != "" {
+		t.Errorf("RefMsg EQP should be cleared, got %q", ref.Item.Media.EQP)
+	}
+	if ref.Item.Media.AESKey != "" {
+		t.Errorf("RefMsg AESKey should be cleared, got %q", ref.Item.Media.AESKey)
+	}
+	wantURL := "https://hub.example.com/api/v1/channels/media?aes=refkey&bot=bot-123&ct=image%2Fjpeg&eqp=eqp-ref-param"
+	if ref.Item.Media.URL != wantURL {
+		t.Errorf("RefMsg media URL = %q, want %q", ref.Item.Media.URL, wantURL)
+	}
+
+	// Original not mutated
+	if items[0].RefMsg.Item.Media.EQP != "eqp-ref-param" {
+		t.Error("original RefMsg should not be mutated")
+	}
+}
+
 func TestResolveMediaURLs_AlreadyStorageURL(t *testing.T) {
 	items := []relay.MessageItem{
 		{

--- a/internal/bot/manager.go
+++ b/internal/bot/manager.go
@@ -817,6 +817,7 @@ func convertRelayItem(item provider.MessageItem) relay.MessageItem {
 	if item.Media != nil {
 		ri.Media = &relay.Media{
 			URL:         item.Media.URL,
+			EQP:         item.Media.EncryptQueryParam,
 			AESKey:      item.Media.AESKey,
 			FileSize:    item.Media.FileSize,
 			MediaType:   item.Media.MediaType,

--- a/internal/bot/manager.go
+++ b/internal/bot/manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strconv"
 	"sync"
 	"time"
@@ -742,9 +743,12 @@ func (m *Manager) processMedia(inst *Instance, msg *provider.InboundMessage) map
 			}
 		} else {
 			// Fallback: proxy URL via Hub (no storage configured)
-			item.Media.URL = fmt.Sprintf("%s/api/v1/channels/media?bot=%s&eqp=%s&aes=%s&ct=%s",
-				m.baseURL, inst.DBID, item.Media.EncryptQueryParam, item.Media.AESKey,
-				mediaContentType(item.Type))
+			q := url.Values{}
+			q.Set("bot", inst.DBID)
+			q.Set("eqp", item.Media.EncryptQueryParam)
+			q.Set("aes", item.Media.AESKey)
+			q.Set("ct", mediaContentType(item.Type))
+			item.Media.URL = fmt.Sprintf("%s/api/v1/channels/media?%s", m.baseURL, q.Encode())
 		}
 	}
 	return silkKeys

--- a/internal/relay/protocol.go
+++ b/internal/relay/protocol.go
@@ -41,6 +41,7 @@ type MessageItem struct {
 
 type Media struct {
 	URL         string `json:"url,omitempty"`
+	EQP         string `json:"eqp,omitempty"`
 	AESKey      string `json:"aes_key,omitempty"`
 	FileSize    int64  `json:"file_size,omitempty"`
 	MediaType   string `json:"media_type,omitempty"`

--- a/internal/relay/protocol.go
+++ b/internal/relay/protocol.go
@@ -41,7 +41,7 @@ type MessageItem struct {
 
 type Media struct {
 	URL         string `json:"url,omitempty"`
-	EQP         string `json:"eqp,omitempty"`
+	EQP         string `json:"-"`
 	AESKey      string `json:"aes_key,omitempty"`
 	FileSize    int64  `json:"file_size,omitempty"`
 	MediaType   string `json:"media_type,omitempty"`

--- a/internal/relay/protocol.go
+++ b/internal/relay/protocol.go
@@ -42,7 +42,7 @@ type MessageItem struct {
 type Media struct {
 	URL         string `json:"url,omitempty"`
 	EQP         string `json:"-"`
-	AESKey      string `json:"aes_key,omitempty"`
+	AESKey      string `json:"-"`
 	FileSize    int64  `json:"file_size,omitempty"`
 	MediaType   string `json:"media_type,omitempty"`
 	PlayTime    int    `json:"play_time,omitempty"`


### PR DESCRIPTION
## Summary

Fixes #203 — WeChat file messages not forwarded to OpenClaw.

**Root cause:** Two issues prevented apps from receiving usable file messages:

1. **Relay items contained raw WeChat CDN URLs** — `convertRelayItem` runs before `processMedia` (async), so apps received inaccessible WeChat CDN URLs instead of Hub proxy URLs
2. **Media proxy endpoints lacked app token auth** — Apps authenticate with `Bearer {app_token}`, but `/api/v1/channels/media` and `/api/v1/media/` only accepted channel API keys and session cookies

**Changes:**

- Add `EQP` field to `relay.Media` to carry `EncryptQueryParam` through to relay items
- Add `resolveMediaURLs()` in `deliverToApps` to replace raw CDN URLs with Hub proxy URLs (`/api/v1/channels/media?bot=...&eqp=...&aes=...&ct=...`) before sending events to apps
- Add Bearer app token auth to both media proxy endpoints (`handleChannelMedia` and `handleMediaProxy`)
- URL-encode all proxy query parameters using `url.Values`

**Companion PR:** Plugin-side changes in `openclaw-channel-openilink` (separate repo) parse `items[]` from events and build `[File: name (size)]\nURL` format for the AI.

## Test plan

- [ ] `go test ./internal/bot/ -run TestResolveMediaURLs` — proxy URL building (3 cases)
- [ ] `go test ./internal/api/ -run TestChannelMedia` — Bearer auth on CDN proxy (3 cases)
- [ ] `go test ./internal/api/ -run TestMediaProxy` — Bearer auth on storage proxy (3 cases)
- [ ] `go test ./internal/...` — full regression suite
- [ ] E2E: Send file from WeChat desktop → verify OpenClaw receives `[File: name (size)]` with download URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps can authenticate to media endpoints using Bearer tokens.
  * Media links delivered to apps are rewritten to route through the Hub's media proxy with bot-binding parameters.

* **Bug Fixes**
  * Stricter media authorization: session-cookie path gated, installation enablement and required scopes enforced, and access requires a connected bot instance.

* **Tests**
  * Added end-to-end and unit tests for media proxy auth/authorization and media URL rewriting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->