### PR TITLE
fix: complete issue 205 app state and routing fixes

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1869,23 +1869,24 @@ func TestMarketplaceInstalledStatusIsPerUser(t *testing.T) {
 	cookie1 := &http.Cookie{Name: "session", Value: session1}
 	cookie2 := &http.Cookie{Name: "session", Value: session2}
 
+	registryApps := []map[string]any{
+		{
+			"slug":        "remote-app",
+			"name":        "Remote App",
+			"description": "Remote app from registry",
+			"version":     "1.0.0",
+			"author":      "Registry Author",
+			"homepage":    "https://example.com/remote-app",
+			"tools":       []any{},
+			"events":      []any{},
+			"scopes":      []string{"message:write"},
+		},
+	}
 	registryTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"version": 1,
-			"apps": []map[string]any{
-				{
-					"slug":        "remote-app",
-					"name":        "Remote App",
-					"description": "Remote app from registry",
-					"version":     "1.0.0",
-					"author":      "Registry Author",
-					"homepage":    "https://example.com/remote-app",
-					"tools":       []any{},
-					"events":      []any{},
-					"scopes":      []string{"message:write"},
-				},
-			},
+			"apps":    registryApps,
 		})
 	}))
 	t.Cleanup(registryTS.Close)
@@ -1950,5 +1951,30 @@ func TestMarketplaceInstalledStatusIsPerUser(t *testing.T) {
 
 	t.Run("other user does not inherit installed status", func(t *testing.T) {
 		assertInstalled(t, cookie2, false)
+	})
+
+	admin, err := s.CreateUserFull("admin", "", "Admin", "hashed", store.RoleAdmin)
+	if err != nil {
+		t.Fatalf("CreateUserFull(admin): %v", err)
+	}
+	_ = s.UpdateUserStatus(admin.ID, store.StatusActive)
+	adminSession, err := auth.CreateSession(s, admin.ID)
+	if err != nil {
+		t.Fatalf("CreateSession(admin): %v", err)
+	}
+	adminCookie := &http.Cookie{Name: "session", Value: adminSession}
+
+	t.Run("unlisting clears installed status for owner", func(t *testing.T) {
+		resp := doJSON(t, ts, "PUT", "/api/admin/apps/"+app.ID+"/listing", map[string]any{
+			"listing": "unlisted",
+		}, withCookie(adminCookie))
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body := decodeJSON(t, resp)
+			t.Fatalf("expected 200, got %d: %v", resp.StatusCode, body)
+		}
+
+		assertInstalled(t, cookie1, false)
 	})
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1978,3 +1978,56 @@ func TestMarketplaceInstalledStatusIsPerUser(t *testing.T) {
 		assertInstalled(t, cookie1, false)
 	})
 }
+
+func TestUpdateListedAppWithEquivalentJSONDoesNotUnlist(t *testing.T) {
+	env := setupTestEnv(t)
+
+	app, err := env.store.CreateApp(&store.App{
+		OwnerID:      env.user.ID,
+		Name:         "Listed App",
+		Slug:         "listed-app",
+		Description:  "listed app",
+		Listing:      "listed",
+		Tools:        json.RawMessage(`[{"name":"tool","description":"Tool"}]`),
+		Events:       json.RawMessage(`["message"]`),
+		Scopes:       json.RawMessage(`["message:read"]`),
+		ConfigSchema: `{"type":"object"}`,
+		Version:      "1.0.0",
+	})
+	if err != nil {
+		t.Fatalf("CreateApp: %v", err)
+	}
+	bot := createTestBot(t, env.store, env.user.ID, "Listed Bot")
+	inst, err := env.store.InstallApp(app.ID, bot.ID)
+	if err != nil {
+		t.Fatalf("InstallApp: %v", err)
+	}
+
+	resp := doJSON(t, env.ts, "PUT", "/api/apps/"+app.ID, map[string]any{
+		"tools":         []map[string]any{{"description": "Tool", "name": "tool"}},
+		"events":        []string{"message"},
+		"scopes":        []string{"message:read"},
+		"config_schema": `{"type":"object"}`,
+		"version":       "1.0.0",
+	}, withCookie(env.cookie))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body := decodeJSON(t, resp)
+		t.Fatalf("expected 200, got %d: %v", resp.StatusCode, body)
+	}
+
+	updated, err := env.store.GetApp(app.ID)
+	if err != nil {
+		t.Fatalf("GetApp: %v", err)
+	}
+	if updated.Listing != "listed" {
+		t.Fatalf("listing = %q, want listed", updated.Listing)
+	}
+	gotInst, err := env.store.GetInstallation(inst.ID)
+	if err != nil {
+		t.Fatalf("GetInstallation: %v", err)
+	}
+	if gotInst.ID != inst.ID {
+		t.Fatalf("installation id = %q, want %q", gotInst.ID, inst.ID)
+	}
+}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1935,13 +1935,20 @@ func TestMarketplaceInstalledStatusIsPerUser(t *testing.T) {
 		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 			t.Fatalf("decode marketplace response: %v", err)
 		}
-		if len(body) != 1 {
-			t.Fatalf("expected 1 marketplace app, got %d", len(body))
+		var remote map[string]any
+		for _, app := range body {
+			if slug, _ := app["slug"].(string); slug == "remote-app" {
+				remote = app
+				break
+			}
+		}
+		if remote == nil {
+			t.Fatalf("remote-app not found in marketplace response: %+v", body)
 		}
 
-		gotInstalled, _ := body[0]["installed"].(bool)
+		gotInstalled, _ := remote["installed"].(bool)
 		if gotInstalled != wantInstalled {
-			t.Fatalf("installed = %v, want %v; body = %+v", gotInstalled, wantInstalled, body[0])
+			t.Fatalf("installed = %v, want %v; body = %+v", gotInstalled, wantInstalled, remote)
 		}
 	}
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2014,7 +2014,7 @@ func TestUpdateListedAppWithEquivalentJSONDoesNotUnlist(t *testing.T) {
 		"tools":         []map[string]any{{"description": "Tool", "name": "tool"}},
 		"events":        []string{"message"},
 		"scopes":        []string{"message:read"},
-		"config_schema": `{"type":"object"}`,
+		"config_schema": "{\n  \"type\": \"object\"\n}",
 		"version":       "1.0.0",
 	}, withCookie(env.cookie))
 	defer resp.Body.Close()

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openilink/openilink-hub/internal/auth"
 	"github.com/openilink/openilink-hub/internal/config"
+	"github.com/openilink/openilink-hub/internal/registry"
 	"github.com/openilink/openilink-hub/internal/store"
 	"github.com/openilink/openilink-hub/internal/store/sqlite"
 )
@@ -1836,4 +1837,118 @@ func TestSetBotAIModel(t *testing.T) {
 	if updated.AIModel != "" {
 		t.Errorf("expected AIModel %q, got %q", "", updated.AIModel)
 	}
+}
+
+func TestMarketplaceInstalledStatusIsPerUser(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := sqlite.Open(dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	user1, err := s.CreateUserFull("user1", "", "User One", "hashed", store.RoleMember)
+	if err != nil {
+		t.Fatalf("CreateUserFull(user1): %v", err)
+	}
+	user2, err := s.CreateUserFull("user2", "", "User Two", "hashed", store.RoleMember)
+	if err != nil {
+		t.Fatalf("CreateUserFull(user2): %v", err)
+	}
+	_ = s.UpdateUserStatus(user1.ID, store.StatusActive)
+	_ = s.UpdateUserStatus(user2.ID, store.StatusActive)
+
+	session1, err := auth.CreateSession(s, user1.ID)
+	if err != nil {
+		t.Fatalf("CreateSession(user1): %v", err)
+	}
+	session2, err := auth.CreateSession(s, user2.ID)
+	if err != nil {
+		t.Fatalf("CreateSession(user2): %v", err)
+	}
+	cookie1 := &http.Cookie{Name: "session", Value: session1}
+	cookie2 := &http.Cookie{Name: "session", Value: session2}
+
+	registryTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"version": 1,
+			"apps": []map[string]any{
+				{
+					"slug":        "remote-app",
+					"name":        "Remote App",
+					"description": "Remote app from registry",
+					"version":     "1.0.0",
+					"author":      "Registry Author",
+					"homepage":    "https://example.com/remote-app",
+					"tools":       []any{},
+					"events":      []any{},
+					"scopes":      []string{"message:write"},
+				},
+			},
+		})
+	}))
+	t.Cleanup(registryTS.Close)
+
+	reg := registry.NewClient(time.Hour)
+	reg.AddSource("Test Registry", registryTS.URL)
+
+	srv := &Server{
+		Store:       s,
+		Registry:    reg,
+		Config:      &config.Config{RPOrigin: "http://localhost"},
+		OAuthStates: newOAuthStateStore(),
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	app, err := s.CreateApp(&store.App{
+		Name:        "Remote App",
+		Slug:        "remote-app",
+		Description: "Remote app from registry",
+		Registry:    registryTS.URL,
+		Version:     "1.0.0",
+		Listing:     "listed",
+		Scopes:      json.RawMessage(`["message:write"]`),
+	})
+	if err != nil {
+		t.Fatalf("CreateApp(remote): %v", err)
+	}
+
+	bot1 := createTestBot(t, s, user1.ID, "User1 Bot")
+	if _, err := s.InstallApp(app.ID, bot1.ID); err != nil {
+		t.Fatalf("InstallApp(user1): %v", err)
+	}
+
+	assertInstalled := func(t *testing.T, cookie *http.Cookie, wantInstalled bool) {
+		t.Helper()
+		resp := doJSON(t, ts, "GET", "/api/marketplace", nil, withCookie(cookie))
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body := decodeJSON(t, resp)
+			t.Fatalf("expected 200, got %d: %v", resp.StatusCode, body)
+		}
+
+		var body []map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode marketplace response: %v", err)
+		}
+		if len(body) != 1 {
+			t.Fatalf("expected 1 marketplace app, got %d", len(body))
+		}
+
+		gotInstalled, _ := body[0]["installed"].(bool)
+		if gotInstalled != wantInstalled {
+			t.Fatalf("installed = %v, want %v; body = %+v", gotInstalled, wantInstalled, body[0])
+		}
+	}
+
+	t.Run("owner of installation sees installed", func(t *testing.T) {
+		assertInstalled(t, cookie1, true)
+	})
+
+	t.Run("other user does not inherit installed status", func(t *testing.T) {
+		assertInstalled(t, cookie2, false)
+	})
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1996,9 +1996,9 @@ func TestUpdateListedAppWithEquivalentJSONDoesNotUnlist(t *testing.T) {
 		Description:  "listed app",
 		Listing:      "listed",
 		Tools:        json.RawMessage(`[{"name":"tool","description":"Tool"}]`),
-		Events:       json.RawMessage(`["message"]`),
-		Scopes:       json.RawMessage(`["message:read"]`),
-		ConfigSchema: `{"type":"object"}`,
+		Events:       json.RawMessage(`["reaction.added","message"]`),
+		Scopes:       json.RawMessage(`["message:write","message:read"]`),
+		ConfigSchema: `{"properties":{"name":{"type":"string"}},"type":"object"}`,
 		Version:      "1.0.0",
 	})
 	if err != nil {
@@ -2012,9 +2012,9 @@ func TestUpdateListedAppWithEquivalentJSONDoesNotUnlist(t *testing.T) {
 
 	resp := doJSON(t, env.ts, "PUT", "/api/apps/"+app.ID, map[string]any{
 		"tools":         []map[string]any{{"description": "Tool", "name": "tool"}},
-		"events":        []string{"message"},
-		"scopes":        []string{"message:read"},
-		"config_schema": "{\n  \"type\": \"object\"\n}",
+		"events":        []string{"message", "reaction.added", "message"},
+		"scopes":        []string{"message:read", "message:write", "message:read"},
+		"config_schema": "{\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": {\n      \"type\": \"string\"\n    }\n  }\n}",
 		"version":       "1.0.0",
 	}, withCookie(env.cookie))
 	defer resp.Body.Close()

--- a/internal/api/app_handler.go
+++ b/internal/api/app_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -63,9 +64,28 @@ func buildListingSnapshot(app *store.App) string {
 	return string(b)
 }
 
-func (s *Server) transitionAppAwayFromListed(appID, currentListing, nextListing string) error {
-	if err := s.Store.TransitionListingWithCleanup(appID, currentListing, nextListing, ""); err != nil {
-		slog.Error("failed to delete installations during listing transition", "app_id", appID, "from", currentListing, "to", nextListing, "err", err)
+func normalizeJSON(raw json.RawMessage) json.RawMessage {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return bytes.TrimSpace(raw)
+	}
+	normalized, err := json.Marshal(v)
+	if err != nil {
+		return bytes.TrimSpace(raw)
+	}
+	return normalized
+}
+
+func jsonRawEqual(a, b json.RawMessage) bool {
+	return bytes.Equal(normalizeJSON(a), normalizeJSON(b))
+}
+
+func (s *Server) transitionAppAwayFromListed(appID, nextListing string) error {
+	if err := s.Store.TransitionListingWithCleanup(appID, nextListing, ""); err != nil {
+		slog.Error("failed to transition app listing with cleanup", "app_id", appID, "to", nextListing, "err", err)
 		return err
 	}
 	return nil
@@ -360,13 +380,13 @@ func (s *Server) handleUpdateApp(w http.ResponseWriter, r *http.Request) {
 		if req.WebhookURL != nil && *req.WebhookURL != app.WebhookURL {
 			coreChanged = true
 		}
-		if req.Tools != nil {
+		if req.Tools != nil && !jsonRawEqual(req.Tools, app.Tools) {
 			coreChanged = true
 		}
-		if req.Events != nil {
+		if req.Events != nil && !jsonRawEqual(req.Events, app.Events) {
 			coreChanged = true
 		}
-		if req.Scopes != nil {
+		if req.Scopes != nil && !jsonRawEqual(req.Scopes, app.Scopes) {
 			coreChanged = true
 		}
 		if req.ConfigSchema != nil && *req.ConfigSchema != app.ConfigSchema {
@@ -377,7 +397,7 @@ func (s *Server) handleUpdateApp(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if coreChanged {
-			if err := s.transitionAppAwayFromListed(appID, app.Listing, "pending"); err != nil {
+			if err := s.transitionAppAwayFromListed(appID, "pending"); err != nil {
 				slog.Error("failed to revert listing to pending", "app", appID, "err", err)
 				jsonError(w, "failed to revert listing", http.StatusInternalServerError)
 				return
@@ -538,7 +558,7 @@ func (s *Server) handleReviewListing(w http.ResponseWriter, r *http.Request) {
 	if req.Approve {
 		err = s.Store.ReviewListing(appID, true, "")
 	} else {
-		err = s.Store.TransitionListingWithCleanup(appID, app.Listing, "rejected", req.Reason)
+		err = s.Store.TransitionListingWithCleanup(appID, "rejected", req.Reason)
 	}
 	if err != nil {
 		jsonError(w, "review failed", http.StatusInternalServerError)
@@ -656,7 +676,7 @@ func (s *Server) handleAdminSetListing(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "app not found", http.StatusNotFound)
 		return
 	}
-	if err := s.transitionAppAwayFromListed(appID, app.Listing, req.Listing); err != nil {
+	if err := s.transitionAppAwayFromListed(appID, req.Listing); err != nil {
 		slog.Error("set listing failed", "err", err)
 		jsonError(w, "set listing failed", http.StatusInternalServerError)
 		return

--- a/internal/api/app_handler.go
+++ b/internal/api/app_handler.go
@@ -63,6 +63,17 @@ func buildListingSnapshot(app *store.App) string {
 	return string(b)
 }
 
+func (s *Server) transitionAppAwayFromListed(appID, currentListing, nextListing string) error {
+	if currentListing != "listed" || nextListing == "listed" {
+		return s.Store.SetListing(appID, nextListing)
+	}
+	if err := s.Store.DeleteInstallationsByAppID(appID); err != nil {
+		slog.Error("failed to delete installations during listing transition", "app_id", appID, "from", currentListing, "to", nextListing, "err", err)
+		return err
+	}
+	return s.Store.SetListing(appID, nextListing)
+}
+
 // POST /api/apps
 func (s *Server) handleCreateApp(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
@@ -82,7 +93,7 @@ func (s *Server) handleCreateApp(w http.ResponseWriter, r *http.Request) {
 		Version          string          `json:"version"`
 		Readme           string          `json:"readme"`
 		Guide            string          `json:"guide"`
-		ConfigSchema     string `json:"config_schema"`
+		ConfigSchema     string          `json:"config_schema"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, "invalid request", http.StatusBadRequest)
@@ -369,7 +380,7 @@ func (s *Server) handleUpdateApp(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if coreChanged {
-			if err := s.Store.SetListing(appID, "pending"); err != nil {
+			if err := s.transitionAppAwayFromListed(appID, app.Listing, "pending"); err != nil {
 				slog.Error("failed to revert listing to pending", "app", appID, "err", err)
 				jsonError(w, "failed to revert listing", http.StatusInternalServerError)
 				return
@@ -526,10 +537,11 @@ func (s *Server) handleReviewListing(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "review failed", http.StatusInternalServerError)
 		return
 	}
-	// When rejecting a listing, remove all installations
 	if !req.Approve {
 		if err := s.Store.DeleteInstallationsByAppID(appID); err != nil {
 			slog.Error("failed to delete installations on reject", "app_id", appID, "err", err)
+			jsonError(w, "review cleanup failed", http.StatusInternalServerError)
+			return
 		}
 	}
 	app, _ := s.Store.GetApp(appID)
@@ -643,19 +655,18 @@ func (s *Server) handleAdminSetListing(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "listing must be 'listed' or 'unlisted'", http.StatusBadRequest)
 		return
 	}
-	if err := s.Store.SetListing(appID, req.Listing); err != nil {
+	app, err := s.Store.GetApp(appID)
+	if err != nil {
+		jsonError(w, "app not found", http.StatusNotFound)
+		return
+	}
+	if err := s.transitionAppAwayFromListed(appID, app.Listing, req.Listing); err != nil {
 		slog.Error("set listing failed", "err", err)
 		jsonError(w, "set listing failed", http.StatusInternalServerError)
 		return
 	}
-	// When unlisting an app, remove all installations so users can re-install after re-listing
-	if req.Listing == "unlisted" {
-		if err := s.Store.DeleteInstallationsByAppID(appID); err != nil {
-			slog.Error("failed to delete installations on delist", "app_id", appID, "err", err)
-		}
-	}
 	slog.Info("admin set listing", "app_id", appID, "listing", req.Listing)
-	app, _ := s.Store.GetApp(appID)
+	app, _ = s.Store.GetApp(appID)
 	if app != nil {
 		if err := s.Store.CreateAppReview(&store.AppReview{
 			AppID:    appID,

--- a/internal/api/app_handler.go
+++ b/internal/api/app_handler.go
@@ -389,7 +389,7 @@ func (s *Server) handleUpdateApp(w http.ResponseWriter, r *http.Request) {
 		if req.Scopes != nil && !jsonRawEqual(req.Scopes, app.Scopes) {
 			coreChanged = true
 		}
-		if req.ConfigSchema != nil && *req.ConfigSchema != app.ConfigSchema {
+		if req.ConfigSchema != nil && !jsonRawEqual(json.RawMessage(*req.ConfigSchema), json.RawMessage(app.ConfigSchema)) {
 			coreChanged = true
 		}
 		if req.Version != nil && *req.Version != app.Version {

--- a/internal/api/app_handler.go
+++ b/internal/api/app_handler.go
@@ -526,6 +526,12 @@ func (s *Server) handleReviewListing(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "review failed", http.StatusInternalServerError)
 		return
 	}
+	// When rejecting a listing, remove all installations
+	if !req.Approve {
+		if err := s.Store.DeleteInstallationsByAppID(appID); err != nil {
+			slog.Error("failed to delete installations on reject", "app_id", appID, "err", err)
+		}
+	}
 	app, _ := s.Store.GetApp(appID)
 	actorID := auth.UserIDFromContext(r.Context())
 	action := "approve"
@@ -641,6 +647,12 @@ func (s *Server) handleAdminSetListing(w http.ResponseWriter, r *http.Request) {
 		slog.Error("set listing failed", "err", err)
 		jsonError(w, "set listing failed", http.StatusInternalServerError)
 		return
+	}
+	// When unlisting an app, remove all installations so users can re-install after re-listing
+	if req.Listing == "unlisted" {
+		if err := s.Store.DeleteInstallationsByAppID(appID); err != nil {
+			slog.Error("failed to delete installations on delist", "app_id", appID, "err", err)
+		}
 	}
 	slog.Info("admin set listing", "app_id", appID, "listing", req.Listing)
 	app, _ := s.Store.GetApp(appID)

--- a/internal/api/app_handler.go
+++ b/internal/api/app_handler.go
@@ -64,14 +64,11 @@ func buildListingSnapshot(app *store.App) string {
 }
 
 func (s *Server) transitionAppAwayFromListed(appID, currentListing, nextListing string) error {
-	if currentListing != "listed" || nextListing == "listed" {
-		return s.Store.SetListing(appID, nextListing)
-	}
-	if err := s.Store.DeleteInstallationsByAppID(appID); err != nil {
+	if err := s.Store.TransitionListingWithCleanup(appID, currentListing, nextListing, ""); err != nil {
 		slog.Error("failed to delete installations during listing transition", "app_id", appID, "from", currentListing, "to", nextListing, "err", err)
 		return err
 	}
-	return s.Store.SetListing(appID, nextListing)
+	return nil
 }
 
 // POST /api/apps
@@ -533,18 +530,21 @@ func (s *Server) handleReviewListing(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "reason required for rejection", http.StatusBadRequest)
 		return
 	}
-	if err := s.Store.ReviewListing(appID, req.Approve, req.Reason); err != nil {
+	app, err := s.Store.GetApp(appID)
+	if err != nil {
+		jsonError(w, "app not found", http.StatusNotFound)
+		return
+	}
+	if req.Approve {
+		err = s.Store.ReviewListing(appID, true, "")
+	} else {
+		err = s.Store.TransitionListingWithCleanup(appID, app.Listing, "rejected", req.Reason)
+	}
+	if err != nil {
 		jsonError(w, "review failed", http.StatusInternalServerError)
 		return
 	}
-	if !req.Approve {
-		if err := s.Store.DeleteInstallationsByAppID(appID); err != nil {
-			slog.Error("failed to delete installations on reject", "app_id", appID, "err", err)
-			jsonError(w, "review cleanup failed", http.StatusInternalServerError)
-			return
-		}
-	}
-	app, _ := s.Store.GetApp(appID)
+	app, _ = s.Store.GetApp(appID)
 	actorID := auth.UserIDFromContext(r.Context())
 	action := "approve"
 	if !req.Approve {

--- a/internal/api/app_handler.go
+++ b/internal/api/app_handler.go
@@ -639,10 +639,6 @@ func (s *Server) requireAppForInstall(w http.ResponseWriter, r *http.Request) *s
 // moderation actions (e.g. emergency takedown, re-listing without re-review).
 func (s *Server) handleAdminSetListing(w http.ResponseWriter, r *http.Request) {
 	appID := r.PathValue("id")
-	if _, err := s.Store.GetApp(appID); err != nil {
-		jsonError(w, "app not found", http.StatusNotFound)
-		return
-	}
 	var req struct {
 		Listing string `json:"listing"`
 	}

--- a/internal/api/app_handler.go
+++ b/internal/api/app_handler.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/openilink/openilink-hub/internal/auth"
@@ -72,7 +73,7 @@ func normalizeJSON(raw json.RawMessage) json.RawMessage {
 	if err := json.Unmarshal(raw, &v); err != nil {
 		return bytes.TrimSpace(raw)
 	}
-	normalized, err := json.Marshal(v)
+	normalized, err := json.Marshal(normalizeJSONValue(v))
 	if err != nil {
 		return bytes.TrimSpace(raw)
 	}
@@ -81,6 +82,75 @@ func normalizeJSON(raw json.RawMessage) json.RawMessage {
 
 func jsonRawEqual(a, b json.RawMessage) bool {
 	return bytes.Equal(normalizeJSON(a), normalizeJSON(b))
+}
+
+func normalizeJSONValue(v any) any {
+	switch value := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(value))
+		for key, item := range value {
+			out[key] = normalizeJSONValue(item)
+		}
+		return out
+	case []any:
+		if len(value) == 0 {
+			return []any{}
+		}
+		if values, ok := normalizeStringSet(value); ok {
+			return values
+		}
+		out := make([]any, len(value))
+		for i, item := range value {
+			out[i] = normalizeJSONValue(item)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func normalizeStringSet(items []any) ([]string, bool) {
+	values := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok {
+			return nil, false
+		}
+		values = append(values, s)
+	}
+	sort.Strings(values)
+	out := values[:0]
+	for _, value := range values {
+		if len(out) > 0 && out[len(out)-1] == value {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out, true
+}
+
+func normalizeCollectionJSON(raw json.RawMessage) json.RawMessage {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return []byte("[]")
+	}
+
+	var v any
+	if err := json.Unmarshal(trimmed, &v); err != nil {
+		return trimmed
+	}
+	if v == nil {
+		return []byte("[]")
+	}
+	normalized, err := json.Marshal(normalizeJSONValue(v))
+	if err != nil {
+		return trimmed
+	}
+	return normalized
+}
+
+func jsonCollectionEqual(a, b json.RawMessage) bool {
+	return bytes.Equal(normalizeCollectionJSON(a), normalizeCollectionJSON(b))
 }
 
 func (s *Server) transitionAppAwayFromListed(appID, nextListing string) error {
@@ -359,61 +429,70 @@ func (s *Server) handleUpdateApp(w http.ResponseWriter, r *http.Request) {
 		scopes = req.Scopes
 	}
 
-	if err := s.Store.UpdateApp(appID, name, description, icon, iconURL, homepage, oauthSetupURL, oauthRedirectURL, configSchema, version, readme, guide, tools, events, scopes); err != nil {
+	webhookURL := app.WebhookURL
+	if req.WebhookURL != nil {
+		webhookURL = *req.WebhookURL
+	}
+
+	coreChanged := false
+	if req.WebhookURL != nil && *req.WebhookURL != app.WebhookURL {
+		coreChanged = true
+	}
+	if req.Tools != nil && !jsonCollectionEqual(req.Tools, app.Tools) {
+		coreChanged = true
+	}
+	if req.Events != nil && !jsonCollectionEqual(req.Events, app.Events) {
+		coreChanged = true
+	}
+	if req.Scopes != nil && !jsonCollectionEqual(req.Scopes, app.Scopes) {
+		coreChanged = true
+	}
+	if req.ConfigSchema != nil && !jsonRawEqual(json.RawMessage(*req.ConfigSchema), json.RawMessage(app.ConfigSchema)) {
+		coreChanged = true
+	}
+	if req.Version != nil && *req.Version != app.Version {
+		coreChanged = true
+	}
+
+	nextListing := ""
+	if app.Listing == "listed" && coreChanged {
+		nextListing = "pending"
+	}
+
+	result, err := s.Store.UpdateAppWithTransition(appID, store.AppUpdate{
+		Name:             name,
+		Description:      description,
+		Icon:             icon,
+		IconURL:          iconURL,
+		Homepage:         homepage,
+		OAuthSetupURL:    oauthSetupURL,
+		OAuthRedirectURL: oauthRedirectURL,
+		WebhookURL:       webhookURL,
+		ConfigSchema:     configSchema,
+		Version:          version,
+		Readme:           readme,
+		Guide:            guide,
+		Tools:            tools,
+		Events:           events,
+		Scopes:           scopes,
+	}, nextListing)
+	if err != nil {
 		jsonError(w, "update failed", http.StatusInternalServerError)
 		return
 	}
 
-	// TODO: webhook_url update is non-atomic with UpdateApp above. If this fails,
-	// the DB is partially updated. Consider merging webhook_url into UpdateApp
-	// or wrapping both in a transaction.
-	if req.WebhookURL != nil && *req.WebhookURL != app.WebhookURL {
-		if err := s.Store.UpdateAppWebhookURL(appID, *req.WebhookURL); err != nil {
-			jsonError(w, "update webhook_url failed", http.StatusInternalServerError)
-			return
-		}
-	}
-
-	// Auto-revert listed apps to pending when core fields change.
-	if app.Listing == "listed" {
-		coreChanged := false
-		if req.WebhookURL != nil && *req.WebhookURL != app.WebhookURL {
-			coreChanged = true
-		}
-		if req.Tools != nil && !jsonRawEqual(req.Tools, app.Tools) {
-			coreChanged = true
-		}
-		if req.Events != nil && !jsonRawEqual(req.Events, app.Events) {
-			coreChanged = true
-		}
-		if req.Scopes != nil && !jsonRawEqual(req.Scopes, app.Scopes) {
-			coreChanged = true
-		}
-		if req.ConfigSchema != nil && !jsonRawEqual(json.RawMessage(*req.ConfigSchema), json.RawMessage(app.ConfigSchema)) {
-			coreChanged = true
-		}
-		if req.Version != nil && *req.Version != app.Version {
-			coreChanged = true
-		}
-
-		if coreChanged {
-			if err := s.transitionAppAwayFromListed(appID, "pending"); err != nil {
-				slog.Error("failed to revert listing to pending", "app", appID, "err", err)
-				jsonError(w, "failed to revert listing", http.StatusInternalServerError)
-				return
-			}
-			slog.Info("listed app core fields changed, reverted to pending", "app", appID)
-			updatedApp, _ := s.Store.GetApp(appID)
-			if updatedApp != nil {
-				if err := s.Store.CreateAppReview(&store.AppReview{
-					AppID:    appID,
-					Action:   "auto_revert",
-					ActorID:  "system",
-					Version:  updatedApp.Version,
-					Snapshot: buildListingSnapshot(updatedApp),
-				}); err != nil {
-					slog.Warn("failed to create app review record", "app", appID, "action", "auto_revert", "err", err)
-				}
+	if result.Transitioned {
+		slog.Info("listed app core fields changed, reverted to pending", "app", appID)
+		updatedApp, _ := s.Store.GetApp(appID)
+		if updatedApp != nil {
+			if err := s.Store.CreateAppReview(&store.AppReview{
+				AppID:    appID,
+				Action:   "auto_revert",
+				ActorID:  "system",
+				Version:  updatedApp.Version,
+				Snapshot: buildListingSnapshot(updatedApp),
+			}); err != nil {
+				slog.Warn("failed to create app review record", "app", appID, "action", "auto_revert", "err", err)
 			}
 		}
 	}

--- a/internal/api/marketplace_handler.go
+++ b/internal/api/marketplace_handler.go
@@ -14,6 +14,8 @@ import (
 
 // GET /api/marketplace — list all available apps from registries, merged with local installs
 func (s *Server) handleMarketplace(w http.ResponseWriter, r *http.Request) {
+	userID := auth.UserIDFromContext(r.Context())
+
 	if s.Registry == nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte("[]"))
@@ -33,6 +35,11 @@ func (s *Server) handleMarketplace(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		jsonError(w, "list local apps failed", http.StatusInternalServerError)
 		return
+	}
+
+	installedIDs, err := s.Store.InstalledAppIDs(userID)
+	if err != nil {
+		slog.Warn("marketplace: failed to load installed app IDs", "user_id", userID, "err", err)
 	}
 
 	// Build lookup: slug → local app
@@ -59,7 +66,7 @@ func (s *Server) handleMarketplace(w http.ResponseWriter, r *http.Request) {
 	for _, ra := range registryApps {
 		entry := marketplaceEntry{AppWithSource: ra}
 		if local, ok := localBySlug[ra.Slug]; ok {
-			entry.Installed = true
+			entry.Installed = installedIDs[local.ID]
 			entry.LocalID = local.ID
 			if ra.Version != "" && ra.Version != local.Version {
 				entry.UpdateAvailable = true

--- a/internal/store/app.go
+++ b/internal/store/app.go
@@ -102,7 +102,7 @@ type AppStore interface {
 	GetInstallationByHandle(botID, handle string) (*AppInstallation, error)
 	DeleteInstallation(id string) error
 	DeleteInstallationsByAppID(appID string) error
-	TransitionListingWithCleanup(id, currentListing, nextListing, rejectReason string) error
+	TransitionListingWithCleanup(id, nextListing, rejectReason string) error
 	CreateOAuthCode(code, appID, botID, state, codeChallenge string) error
 	ExchangeOAuthCode(code string) (appID, botID, codeChallenge string, err error)
 	CleanExpiredOAuthCodes()

--- a/internal/store/app.go
+++ b/internal/store/app.go
@@ -101,6 +101,7 @@ type AppStore interface {
 	RegenerateInstallationToken(id string) (string, error)
 	GetInstallationByHandle(botID, handle string) (*AppInstallation, error)
 	DeleteInstallation(id string) error
+	DeleteInstallationsByAppID(appID string) error
 	CreateOAuthCode(code, appID, botID, state, codeChallenge string) error
 	ExchangeOAuthCode(code string) (appID, botID, codeChallenge string, err error)
 	CleanExpiredOAuthCodes()

--- a/internal/store/app.go
+++ b/internal/store/app.go
@@ -70,7 +70,7 @@ type AppInstallation struct {
 type AppReview struct {
 	ID        string `json:"id"`
 	AppID     string `json:"app_id"`
-	Action    string `json:"action"`    // request, approve, reject, withdraw, auto_revert, admin_set
+	Action    string `json:"action"` // request, approve, reject, withdraw, auto_revert, admin_set
 	ActorID   string `json:"actor_id"`
 	Reason    string `json:"reason"`
 	Version   string `json:"version"`
@@ -102,6 +102,7 @@ type AppStore interface {
 	GetInstallationByHandle(botID, handle string) (*AppInstallation, error)
 	DeleteInstallation(id string) error
 	DeleteInstallationsByAppID(appID string) error
+	TransitionListingWithCleanup(id, currentListing, nextListing, rejectReason string) error
 	CreateOAuthCode(code, appID, botID, state, codeChallenge string) error
 	ExchangeOAuthCode(code string) (appID, botID, codeChallenge string, err error)
 	CleanExpiredOAuthCodes()

--- a/internal/store/app.go
+++ b/internal/store/app.go
@@ -78,6 +78,29 @@ type AppReview struct {
 	CreatedAt int64  `json:"created_at"`
 }
 
+type AppUpdate struct {
+	Name             string
+	Description      string
+	Icon             string
+	IconURL          string
+	Homepage         string
+	OAuthSetupURL    string
+	OAuthRedirectURL string
+	WebhookURL       string
+	ConfigSchema     string
+	Version          string
+	Readme           string
+	Guide            string
+	Tools            json.RawMessage
+	Events           json.RawMessage
+	Scopes           json.RawMessage
+}
+
+type AppUpdateResult struct {
+	Listing      string
+	Transitioned bool
+}
+
 type AppStore interface {
 	CreateApp(app *App) (*App, error)
 	GetApp(id string) (*App, error)
@@ -87,6 +110,7 @@ type AppStore interface {
 	ListAllApps() ([]App, error)
 	ListMarketplaceApps() ([]App, error)
 	UpdateApp(id string, name, description, icon, iconURL, homepage, oauthSetupURL, oauthRedirectURL, configSchema, version, readme, guide string, tools, events, scopes json.RawMessage) error
+	UpdateAppWithTransition(id string, update AppUpdate, nextListing string) (AppUpdateResult, error)
 	UpdateMarketplaceApp(id, name, description, iconURL, homepage, webhookURL, oauthSetupURL, oauthRedirectURL, version, readme, guide string, tools, events, scopes json.RawMessage) error
 	DeleteApp(id string) error
 	InstallApp(appID, botID string) (*AppInstallation, error)

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -159,12 +159,16 @@ func (s *Store) ListRecentContacts(botID string, limit int) ([]store.RecentConta
 	return out, nil
 }
 
-func (s *Store) ListBotsByUser(string) ([]store.Bot, error)                      { return nil, nil }
+func (s *Store) ListBotsByUser(string) ([]store.Bot, error) { return nil, nil }
 func (s *Store) CreateBot(string, string, string, string, json.RawMessage) (*store.Bot, error) {
 	return nil, errNotImplemented
 }
-func (s *Store) FindBotByProviderID(string, string) (*store.Bot, error) { return nil, errNotImplemented }
-func (s *Store) FindBotByCredential(string, string) (*store.Bot, error) { return nil, errNotImplemented }
+func (s *Store) FindBotByProviderID(string, string) (*store.Bot, error) {
+	return nil, errNotImplemented
+}
+func (s *Store) FindBotByCredential(string, string) (*store.Bot, error) {
+	return nil, errNotImplemented
+}
 func (s *Store) UpdateBotCredentials(string, string, json.RawMessage) error { return nil }
 func (s *Store) UpdateBotName(string, string) error                         { return nil }
 func (s *Store) UpdateBotDisplayName(string, string) error                  { return nil }
@@ -226,9 +230,9 @@ func (s *Store) GetBotStats(userID string) (*store.BotStats, error) {
 	}
 	return stats, nil
 }
-func (s *Store) UpdateBotAIEnabled(string, bool) error                      { return nil }
-func (s *Store) UpdateBotAIModel(string, string) error                      { return nil }
-func (s *Store) LastActivityAt(string) *time.Time                           { return nil }
+func (s *Store) UpdateBotAIEnabled(string, bool) error { return nil }
+func (s *Store) UpdateBotAIModel(string, string) error { return nil }
+func (s *Store) LastActivityAt(string) *time.Time      { return nil }
 
 // --- MessageStore (implemented) ---
 
@@ -259,8 +263,8 @@ func (s *Store) BatchHasFreshContextToken(botIDs []string, maxAge time.Duration)
 	return result
 }
 
-func (s *Store) GetMessage(int64) (*store.Message, error)                     { return nil, errNotImplemented }
-func (s *Store) ListMessages(string, int, int64) ([]store.Message, error)     { return nil, nil }
+func (s *Store) GetMessage(int64) (*store.Message, error)                          { return nil, errNotImplemented }
+func (s *Store) ListMessages(string, int, int64) ([]store.Message, error)          { return nil, nil }
 func (s *Store) ListMessagesBySender(string, string, int) ([]store.Message, error) { return nil, nil }
 func (s *Store) ListChannelMessages(string, string, int) ([]store.Message, error)  { return nil, nil }
 func (s *Store) GetMessagesSince(string, int64, int) ([]store.Message, error)      { return nil, nil }
@@ -356,7 +360,7 @@ func (s *Store) GetInstallation(id string) (*store.AppInstallation, error) {
 	return &cp, nil
 }
 
-func (s *Store) CreateApp(*store.App) (*store.App, error) { return nil, errNotImplemented }
+func (s *Store) CreateApp(*store.App) (*store.App, error)        { return nil, errNotImplemented }
 func (s *Store) GetAppBySlug(string, string) (*store.App, error) { return nil, errNotImplemented }
 func (s *Store) ListAppsByOwner(string) ([]store.App, error)     { return nil, nil }
 func (s *Store) ListListedApps() ([]store.App, error)            { return nil, nil }
@@ -368,28 +372,46 @@ func (s *Store) UpdateApp(string, string, string, string, string, string, string
 func (s *Store) UpdateMarketplaceApp(string, string, string, string, string, string, string, string, string, string, string, json.RawMessage, json.RawMessage, json.RawMessage) error {
 	return nil
 }
-func (s *Store) DeleteApp(string) error                                     { return nil }
-func (s *Store) InstallApp(string, string) (*store.AppInstallation, error)  { return nil, errNotImplemented }
-func (s *Store) InstalledAppIDs(string) (map[string]bool, error) { return nil, nil }
+func (s *Store) DeleteApp(string) error { return nil }
+func (s *Store) InstallApp(string, string) (*store.AppInstallation, error) {
+	return nil, errNotImplemented
+}
+func (s *Store) InstalledAppIDs(string) (map[string]bool, error)                { return nil, nil }
 func (s *Store) ListInstallationsByApp(string) ([]store.AppInstallation, error) { return nil, nil }
 func (s *Store) UpdateInstallation(string, string, json.RawMessage, json.RawMessage, bool) error {
 	return nil
 }
-func (s *Store) SetAppWebhookVerified(string, bool) error      { return nil }
-func (s *Store) UpdateAppWebhookURL(string, string) error      { return nil }
+func (s *Store) SetAppWebhookVerified(string, bool) error           { return nil }
+func (s *Store) UpdateAppWebhookURL(string, string) error           { return nil }
 func (s *Store) RegenerateInstallationToken(string) (string, error) { return "", errNotImplemented }
 func (s *Store) DeleteInstallation(string) error                    { return nil }
-func (s *Store) DeleteInstallationsByAppID(string) error            { return nil }
+func (s *Store) DeleteInstallationsByAppID(appID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, inst := range s.installations {
+		if inst.AppID != appID {
+			continue
+		}
+		delete(s.installations, id)
+		if inst.AppToken != "" {
+			delete(s.tokenIndex, inst.AppToken)
+		}
+		if inst.Handle != "" && inst.BotID != "" {
+			delete(s.handleIndex, inst.BotID+":"+inst.Handle)
+		}
+	}
+	return nil
+}
 func (s *Store) CreateOAuthCode(string, string, string, string, string) error { return nil }
 func (s *Store) ExchangeOAuthCode(string) (string, string, string, error) {
 	return "", "", "", errNotImplemented
 }
-func (s *Store) CleanExpiredOAuthCodes()            {}
-func (s *Store) RequestListing(string) error        { return nil }
-func (s *Store) ReviewListing(string, bool, string) error { return nil }
-func (s *Store) WithdrawListing(string) error       { return nil }
-func (s *Store) SetListing(string, string) error    { return nil }
-func (s *Store) CreateAppReview(*store.AppReview) error { return nil }
+func (s *Store) CleanExpiredOAuthCodes()                          {}
+func (s *Store) RequestListing(string) error                      { return nil }
+func (s *Store) ReviewListing(string, bool, string) error         { return nil }
+func (s *Store) WithdrawListing(string) error                     { return nil }
+func (s *Store) SetListing(string, string) error                  { return nil }
+func (s *Store) CreateAppReview(*store.AppReview) error           { return nil }
 func (s *Store) ListAppReviews(string) ([]store.AppReview, error) { return nil, nil }
 
 // --- AppLogStore (implemented) ---
@@ -404,8 +426,8 @@ func (s *Store) CreateEventLog(log *store.AppEventLog) (int64, error) {
 	return id, nil
 }
 
-func (s *Store) UpdateEventLogDelivered(int64, int, string, int) error { return nil }
-func (s *Store) UpdateEventLogFailed(int64, string, int, int) error    { return nil }
+func (s *Store) UpdateEventLogDelivered(int64, int, string, int) error  { return nil }
+func (s *Store) UpdateEventLogFailed(int64, string, int, int) error     { return nil }
 func (s *Store) ListEventLogs(string, int) ([]store.AppEventLog, error) { return nil, nil }
 func (s *Store) CreateAPILog(log *store.AppAPILog) error {
 	s.mu.Lock()
@@ -415,7 +437,7 @@ func (s *Store) CreateAPILog(log *store.AppAPILog) error {
 	return nil
 }
 func (s *Store) ListAPILogs(string, int) ([]store.AppAPILog, error) { return nil, nil }
-func (s *Store) CleanOldAppLogs(int) error                         { return nil }
+func (s *Store) CleanOldAppLogs(int) error                          { return nil }
 
 // --- TraceStore (no-op) ---
 
@@ -425,8 +447,8 @@ func (s *Store) InsertSpan(string, string, string, string, string, string, strin
 func (s *Store) AppendSpan(string, string, string, string, string, string, map[string]any) error {
 	return nil
 }
-func (s *Store) ListRootSpans(string, int) ([]store.TraceSpan, error)  { return nil, nil }
-func (s *Store) ListSpansByTrace(string) ([]store.TraceSpan, error)    { return nil, nil }
+func (s *Store) ListRootSpans(string, int) ([]store.TraceSpan, error) { return nil, nil }
+func (s *Store) ListSpansByTrace(string) ([]store.TraceSpan, error)   { return nil, nil }
 
 // --- UserStore (stub) ---
 
@@ -445,93 +467,99 @@ func (s *Store) UpdateUserProfile(string, string, string) error { return nil }
 func (s *Store) UpdateUserPassword(string, string) error        { return nil }
 func (s *Store) UpdateUserRole(string, string) error            { return nil }
 func (s *Store) UpdateUserStatus(string, string) error          { return nil }
-func (s *Store) UpdateUserUsername(string, string) error         { return nil }
+func (s *Store) UpdateUserUsername(string, string) error        { return nil }
 func (s *Store) DeleteUser(string) error                        { return nil }
 
 // --- SessionStore (stub) ---
 
-func (s *Store) CreateSession(string, string, time.Time) error                { return nil }
-func (s *Store) GetSession(string) (string, time.Time, error)                 { return "", time.Time{}, errNotImplemented }
-func (s *Store) DeleteSession(string) error                                    { return nil }
-func (s *Store) DeleteExpiredSessions() error                                  { return nil }
-func (s *Store) DeleteSessionsByUserID(string) error                           { return nil }
+func (s *Store) CreateSession(string, string, time.Time) error { return nil }
+func (s *Store) GetSession(string) (string, time.Time, error) {
+	return "", time.Time{}, errNotImplemented
+}
+func (s *Store) DeleteSession(string) error          { return nil }
+func (s *Store) DeleteExpiredSessions() error        { return nil }
+func (s *Store) DeleteSessionsByUserID(string) error { return nil }
 
 // --- ChannelStore (stub) ---
 
 func (s *Store) CreateChannel(string, string, string, *store.FilterRule, *store.AIConfig) (*store.Channel, error) {
 	return nil, errNotImplemented
 }
-func (s *Store) GetChannel(string) (*store.Channel, error)          { return nil, errNotImplemented }
-func (s *Store) GetChannelByAPIKey(string) (*store.Channel, error)  { return nil, errNotImplemented }
-func (s *Store) ListChannelsByBot(string) ([]store.Channel, error)  { return nil, nil }
+func (s *Store) GetChannel(string) (*store.Channel, error)              { return nil, errNotImplemented }
+func (s *Store) GetChannelByAPIKey(string) (*store.Channel, error)      { return nil, errNotImplemented }
+func (s *Store) ListChannelsByBot(string) ([]store.Channel, error)      { return nil, nil }
 func (s *Store) ListChannelsByBotIDs([]string) ([]store.Channel, error) { return nil, nil }
 func (s *Store) UpdateChannel(string, string, string, *store.FilterRule, *store.AIConfig, *store.WebhookConfig, bool) error {
 	return nil
 }
-func (s *Store) DeleteChannel(string) error                    { return nil }
-func (s *Store) RotateChannelKey(string) (string, error)       { return "", errNotImplemented }
-func (s *Store) UpdateChannelLastSeq(string, int64) error      { return nil }
-func (s *Store) CountChannelsByBot(string) (int, error)        { return 0, nil }
+func (s *Store) DeleteChannel(string) error               { return nil }
+func (s *Store) RotateChannelKey(string) (string, error)  { return "", errNotImplemented }
+func (s *Store) UpdateChannelLastSeq(string, int64) error { return nil }
+func (s *Store) CountChannelsByBot(string) (int, error)   { return 0, nil }
 
 // --- CredentialStore (stub) ---
 
-func (s *Store) SaveCredential(*store.Credential) error                  { return nil }
+func (s *Store) SaveCredential(*store.Credential) error                    { return nil }
 func (s *Store) GetCredentialsByUserID(string) ([]store.Credential, error) { return nil, nil }
-func (s *Store) UpdateCredentialSignCount(string, uint32) error          { return nil }
+func (s *Store) UpdateCredentialSignCount(string, uint32) error            { return nil }
 func (s *Store) UpdateCredentialName(string, string, string) (bool, error) { return false, nil }
-func (s *Store) DeleteCredential(string, string) error                   { return nil }
+func (s *Store) DeleteCredential(string, string) error                     { return nil }
 
 // --- OAuthStore (stub) ---
 
-func (s *Store) GetOAuthAccount(string, string) (*store.OAuthAccount, error) { return nil, errNotImplemented }
-func (s *Store) CreateOAuthAccount(*store.OAuthAccount) error                { return nil }
-func (s *Store) DeleteOAuthAccount(string, string) error                     { return nil }
+func (s *Store) GetOAuthAccount(string, string) (*store.OAuthAccount, error) {
+	return nil, errNotImplemented
+}
+func (s *Store) CreateOAuthAccount(*store.OAuthAccount) error                 { return nil }
+func (s *Store) DeleteOAuthAccount(string, string) error                      { return nil }
 func (s *Store) ListOAuthAccountsByUser(string) ([]store.OAuthAccount, error) { return nil, nil }
 
 // --- ConfigStore (stub) ---
 
-func (s *Store) GetConfig(string) (string, error)                   { return "", errNotImplemented }
-func (s *Store) SetConfig(string, string) error                     { return nil }
-func (s *Store) DeleteConfig(string) error                          { return nil }
+func (s *Store) GetConfig(string) (string, error)                     { return "", errNotImplemented }
+func (s *Store) SetConfig(string, string) error                       { return nil }
+func (s *Store) DeleteConfig(string) error                            { return nil }
 func (s *Store) ListConfigByPrefix(string) (map[string]string, error) { return nil, nil }
 
 // --- RegistryStore (stub) ---
 
-func (s *Store) ListRegistries() ([]store.Registry, error)  { return nil, nil }
-func (s *Store) CreateRegistry(*store.Registry) error       { return nil }
-func (s *Store) UpdateRegistryEnabled(string, bool) error   { return nil }
-func (s *Store) DeleteRegistry(string) error                { return nil }
+func (s *Store) ListRegistries() ([]store.Registry, error) { return nil, nil }
+func (s *Store) CreateRegistry(*store.Registry) error      { return nil }
+func (s *Store) UpdateRegistryEnabled(string, bool) error  { return nil }
+func (s *Store) DeleteRegistry(string) error               { return nil }
 
 // --- PluginStore (stub) ---
 
-func (s *Store) CreatePlugin(*store.Plugin) (*store.Plugin, error)  { return nil, errNotImplemented }
-func (s *Store) GetPlugin(string) (*store.Plugin, error)            { return nil, errNotImplemented }
-func (s *Store) GetPluginByName(string) (*store.Plugin, error)      { return nil, errNotImplemented }
-func (s *Store) ListPlugins() ([]store.PluginWithLatest, error)     { return nil, nil }
+func (s *Store) CreatePlugin(*store.Plugin) (*store.Plugin, error)           { return nil, errNotImplemented }
+func (s *Store) GetPlugin(string) (*store.Plugin, error)                     { return nil, errNotImplemented }
+func (s *Store) GetPluginByName(string) (*store.Plugin, error)               { return nil, errNotImplemented }
+func (s *Store) ListPlugins() ([]store.PluginWithLatest, error)              { return nil, nil }
 func (s *Store) ListPluginsByOwner(string) ([]store.PluginWithLatest, error) { return nil, nil }
-func (s *Store) UpdatePluginMeta(string, *store.Plugin) error       { return nil }
-func (s *Store) DeletePlugin(string) error                          { return nil }
+func (s *Store) UpdatePluginMeta(string, *store.Plugin) error                { return nil }
+func (s *Store) DeletePlugin(string) error                                   { return nil }
 func (s *Store) CreatePluginVersion(*store.PluginVersion) (*store.PluginVersion, error) {
 	return nil, errNotImplemented
 }
-func (s *Store) GetPluginVersion(string) (*store.PluginVersion, error)  { return nil, errNotImplemented }
+func (s *Store) GetPluginVersion(string) (*store.PluginVersion, error)    { return nil, errNotImplemented }
 func (s *Store) ListPluginVersions(string) ([]store.PluginVersion, error) { return nil, nil }
-func (s *Store) ListPendingVersions() ([]store.PluginVersion, error)    { return nil, nil }
-func (s *Store) SupersedeNonApprovedVersions(string)                    {}
-func (s *Store) FindPendingVersion(string) (*store.PluginVersion, error) { return nil, errNotImplemented }
-func (s *Store) UpdatePluginVersion(string, *store.PluginVersion) error { return nil }
+func (s *Store) ListPendingVersions() ([]store.PluginVersion, error)      { return nil, nil }
+func (s *Store) SupersedeNonApprovedVersions(string)                      {}
+func (s *Store) FindPendingVersion(string) (*store.PluginVersion, error) {
+	return nil, errNotImplemented
+}
+func (s *Store) UpdatePluginVersion(string, *store.PluginVersion) error   { return nil }
 func (s *Store) ReviewPluginVersion(string, string, string, string) error { return nil }
-func (s *Store) DeletePluginVersion(string) error                       { return nil }
-func (s *Store) RecordPluginInstall(string, string) error               { return nil }
-func (s *Store) CancelPluginVersion(string) error                      { return nil }
-func (s *Store) FindPluginOwner(string) (string, error)                { return "", errNotImplemented }
+func (s *Store) DeletePluginVersion(string) error                         { return nil }
+func (s *Store) RecordPluginInstall(string, string) error                 { return nil }
+func (s *Store) CancelPluginVersion(string) error                         { return nil }
+func (s *Store) FindPluginOwner(string) (string, error)                   { return "", errNotImplemented }
 func (s *Store) ResolvePluginScript(string) (string, string, int, error) {
 	return "", "", 0, errNotImplemented
 }
 
 // --- WebhookLogStore (stub) ---
 
-func (s *Store) CreateWebhookLog(*store.WebhookLog) (int64, error)          { return 0, nil }
+func (s *Store) CreateWebhookLog(*store.WebhookLog) (int64, error)                   { return 0, nil }
 func (s *Store) UpdateWebhookLogRequest(int64, string, string, string, string) error { return nil }
 func (s *Store) UpdateWebhookLogResponse(int64, string, int, string, int) error      { return nil }
 func (s *Store) UpdateWebhookLogResult(int64, string, string, []string) error        { return nil }

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -402,7 +402,7 @@ func (s *Store) DeleteInstallationsByAppID(appID string) error {
 	}
 	return nil
 }
-func (s *Store) TransitionListingWithCleanup(id, currentListing, nextListing, rejectReason string) error {
+func (s *Store) TransitionListingWithCleanup(id, nextListing, rejectReason string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -410,6 +410,7 @@ func (s *Store) TransitionListingWithCleanup(id, currentListing, nextListing, re
 	if !ok {
 		return fmt.Errorf("app %s not found", id)
 	}
+	currentListing := app.Listing
 	if currentListing == "listed" && nextListing != "listed" {
 		for instID, inst := range s.installations {
 			if inst.AppID != id {

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -385,9 +385,8 @@ func (s *Store) SetAppWebhookVerified(string, bool) error           { return nil
 func (s *Store) UpdateAppWebhookURL(string, string) error           { return nil }
 func (s *Store) RegenerateInstallationToken(string) (string, error) { return "", errNotImplemented }
 func (s *Store) DeleteInstallation(string) error                    { return nil }
-func (s *Store) DeleteInstallationsByAppID(appID string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+
+func (s *Store) deleteInstallationsByAppIDLocked(appID string) {
 	for id, inst := range s.installations {
 		if inst.AppID != appID {
 			continue
@@ -400,6 +399,12 @@ func (s *Store) DeleteInstallationsByAppID(appID string) error {
 			delete(s.handleIndex, inst.BotID+":"+inst.Handle)
 		}
 	}
+}
+
+func (s *Store) DeleteInstallationsByAppID(appID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deleteInstallationsByAppIDLocked(appID)
 	return nil
 }
 func (s *Store) TransitionListingWithCleanup(id, nextListing, rejectReason string) error {
@@ -412,18 +417,7 @@ func (s *Store) TransitionListingWithCleanup(id, nextListing, rejectReason strin
 	}
 	currentListing := app.Listing
 	if currentListing == "listed" && nextListing != "listed" {
-		for instID, inst := range s.installations {
-			if inst.AppID != id {
-				continue
-			}
-			delete(s.installations, instID)
-			if inst.AppToken != "" {
-				delete(s.tokenIndex, inst.AppToken)
-			}
-			if inst.Handle != "" && inst.BotID != "" {
-				delete(s.handleIndex, inst.BotID+":"+inst.Handle)
-			}
-		}
+		s.deleteInstallationsByAppIDLocked(id)
 	}
 	app.Listing = nextListing
 	if nextListing == "rejected" {

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -379,6 +379,7 @@ func (s *Store) SetAppWebhookVerified(string, bool) error      { return nil }
 func (s *Store) UpdateAppWebhookURL(string, string) error      { return nil }
 func (s *Store) RegenerateInstallationToken(string) (string, error) { return "", errNotImplemented }
 func (s *Store) DeleteInstallation(string) error                    { return nil }
+func (s *Store) DeleteInstallationsByAppID(string) error            { return nil }
 func (s *Store) CreateOAuthCode(string, string, string, string, string) error { return nil }
 func (s *Store) ExchangeOAuthCode(string) (string, string, string, error) {
 	return "", "", "", errNotImplemented

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -402,6 +402,36 @@ func (s *Store) DeleteInstallationsByAppID(appID string) error {
 	}
 	return nil
 }
+func (s *Store) TransitionListingWithCleanup(id, currentListing, nextListing, rejectReason string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	app, ok := s.apps[id]
+	if !ok {
+		return fmt.Errorf("app %s not found", id)
+	}
+	if currentListing == "listed" && nextListing != "listed" {
+		for instID, inst := range s.installations {
+			if inst.AppID != id {
+				continue
+			}
+			delete(s.installations, instID)
+			if inst.AppToken != "" {
+				delete(s.tokenIndex, inst.AppToken)
+			}
+			if inst.Handle != "" && inst.BotID != "" {
+				delete(s.handleIndex, inst.BotID+":"+inst.Handle)
+			}
+		}
+	}
+	app.Listing = nextListing
+	if nextListing == "rejected" {
+		app.ListingRejectReason = rejectReason
+	} else {
+		app.ListingRejectReason = ""
+	}
+	return nil
+}
 func (s *Store) CreateOAuthCode(string, string, string, string, string) error { return nil }
 func (s *Store) ExchangeOAuthCode(string) (string, string, string, error) {
 	return "", "", "", errNotImplemented

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -369,6 +369,48 @@ func (s *Store) ListMarketplaceApps() ([]store.App, error)       { return nil, n
 func (s *Store) UpdateApp(string, string, string, string, string, string, string, string, string, string, string, string, json.RawMessage, json.RawMessage, json.RawMessage) error {
 	return nil
 }
+func (s *Store) UpdateAppWithTransition(id string, update store.AppUpdate, nextListing string) (store.AppUpdateResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	app, ok := s.apps[id]
+	if !ok {
+		return store.AppUpdateResult{}, fmt.Errorf("app %s not found", id)
+	}
+
+	currentListing := app.Listing
+	webhookChanged := app.WebhookURL != update.WebhookURL
+
+	app.Name = update.Name
+	app.Description = update.Description
+	app.Icon = update.Icon
+	app.IconURL = update.IconURL
+	app.Homepage = update.Homepage
+	app.OAuthSetupURL = update.OAuthSetupURL
+	app.OAuthRedirectURL = update.OAuthRedirectURL
+	app.WebhookURL = update.WebhookURL
+	app.ConfigSchema = update.ConfigSchema
+	app.Version = update.Version
+	app.Readme = update.Readme
+	app.Guide = update.Guide
+	app.Tools = update.Tools
+	app.Events = update.Events
+	app.Scopes = update.Scopes
+	if webhookChanged {
+		app.WebhookVerified = false
+	}
+
+	result := store.AppUpdateResult{Listing: currentListing}
+	if currentListing == "listed" && nextListing != "" && nextListing != "listed" {
+		s.deleteInstallationsByAppIDLocked(id)
+		app.Listing = nextListing
+		app.ListingRejectReason = ""
+		result.Listing = nextListing
+		result.Transitioned = true
+	}
+
+	return result, nil
+}
 func (s *Store) UpdateMarketplaceApp(string, string, string, string, string, string, string, string, string, string, string, json.RawMessage, json.RawMessage, json.RawMessage) error {
 	return nil
 }

--- a/internal/store/postgres/app.go
+++ b/internal/store/postgres/app.go
@@ -408,12 +408,17 @@ func (db *DB) DeleteInstallationsByAppID(appID string) error {
 	return err
 }
 
-func (db *DB) TransitionListingWithCleanup(id, currentListing, nextListing, rejectReason string) error {
+func (db *DB) TransitionListingWithCleanup(id, nextListing, rejectReason string) error {
 	tx, err := db.Begin()
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
+
+	var currentListing string
+	if err := tx.QueryRow("SELECT listing FROM apps WHERE id = $1", id).Scan(&currentListing); err != nil {
+		return err
+	}
 
 	if currentListing == "listed" && nextListing != "listed" {
 		if _, err := tx.Exec("DELETE FROM app_installations WHERE app_id = $1", id); err != nil {

--- a/internal/store/postgres/app.go
+++ b/internal/store/postgres/app.go
@@ -403,6 +403,11 @@ func (db *DB) DeleteInstallation(id string) error {
 	return err
 }
 
+func (db *DB) DeleteInstallationsByAppID(appID string) error {
+	_, err := db.Exec("DELETE FROM app_installations WHERE app_id = $1", appID)
+	return err
+}
+
 func (db *DB) CreateOAuthCode(code, appID, botID, state, codeChallenge string) error {
 	_, err := db.Exec(`INSERT INTO app_oauth_codes (code, app_id, bot_id, state, code_challenge) VALUES ($1,$2,$3,$4,$5)`,
 		code, appID, botID, state, codeChallenge)

--- a/internal/store/postgres/app.go
+++ b/internal/store/postgres/app.go
@@ -408,6 +408,30 @@ func (db *DB) DeleteInstallationsByAppID(appID string) error {
 	return err
 }
 
+func (db *DB) TransitionListingWithCleanup(id, currentListing, nextListing, rejectReason string) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if currentListing == "listed" && nextListing != "listed" {
+		if _, err := tx.Exec("DELETE FROM app_installations WHERE app_id = $1", id); err != nil {
+			return err
+		}
+	}
+
+	reason := ""
+	if nextListing == "rejected" {
+		reason = rejectReason
+	}
+	if _, err := tx.Exec("UPDATE apps SET listing=$1, listing_reject_reason=$2, updated_at=$3 WHERE id=$4", nextListing, reason, db.now(), id); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
 func (db *DB) CreateOAuthCode(code, appID, botID, state, codeChallenge string) error {
 	_, err := db.Exec(`INSERT INTO app_oauth_codes (code, app_id, bot_id, state, code_challenge) VALUES ($1,$2,$3,$4,$5)`,
 		code, appID, botID, state, codeChallenge)

--- a/internal/store/postgres/app.go
+++ b/internal/store/postgres/app.go
@@ -223,6 +223,47 @@ func (db *DB) UpdateApp(id string, name, description, icon, iconURL, homepage, o
 	return err
 }
 
+func (db *DB) UpdateAppWithTransition(id string, update store.AppUpdate, nextListing string) (store.AppUpdateResult, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return store.AppUpdateResult{}, err
+	}
+	defer tx.Rollback()
+
+	var currentListing string
+	if err := tx.QueryRow("SELECT listing FROM apps WHERE id = $1 FOR UPDATE", id).Scan(&currentListing); err != nil {
+		return store.AppUpdateResult{}, err
+	}
+
+	if _, err := tx.Exec(`UPDATE apps SET name=$1, description=$2, icon=$3, icon_url=$4, homepage=$5,
+		tools=$6, events=$7, scopes=$8, oauth_setup_url=$9, oauth_redirect_url=$10, webhook_url=$11,
+		webhook_verified=CASE WHEN webhook_url <> $11 THEN FALSE ELSE webhook_verified END,
+		config_schema=$12, version=$13, readme=$14, guide=$15, updated_at=$16 WHERE id=$17`,
+		update.Name, update.Description, update.Icon, update.IconURL, update.Homepage,
+		update.Tools, update.Events, update.Scopes, update.OAuthSetupURL, update.OAuthRedirectURL, update.WebhookURL,
+		update.ConfigSchema, update.Version, update.Readme, update.Guide, db.now(), id,
+	); err != nil {
+		return store.AppUpdateResult{}, err
+	}
+
+	result := store.AppUpdateResult{Listing: currentListing}
+	if currentListing == "listed" && nextListing != "" && nextListing != "listed" {
+		if _, err := tx.Exec("DELETE FROM app_installations WHERE app_id = $1", id); err != nil {
+			return store.AppUpdateResult{}, err
+		}
+		if _, err := tx.Exec("UPDATE apps SET listing=$1, listing_reject_reason='', updated_at=$2 WHERE id=$3", nextListing, db.now(), id); err != nil {
+			return store.AppUpdateResult{}, err
+		}
+		result.Listing = nextListing
+		result.Transitioned = true
+	}
+
+	if err := tx.Commit(); err != nil {
+		return store.AppUpdateResult{}, err
+	}
+	return result, nil
+}
+
 func (db *DB) UpdateMarketplaceApp(id, name, description, iconURL, homepage, webhookURL, oauthSetupURL, oauthRedirectURL, version, readme, guide string, tools, events, scopes json.RawMessage) error {
 	_, err := db.Exec(`UPDATE apps SET name=$1, description=$2, icon_url=$3, homepage=$4,
 		webhook_url=$5, oauth_setup_url=$6, oauth_redirect_url=$7, version=$8, readme=$9, guide=$10,

--- a/internal/store/sqlite/app.go
+++ b/internal/store/sqlite/app.go
@@ -415,12 +415,17 @@ func (db *DB) DeleteInstallationsByAppID(appID string) error {
 	return err
 }
 
-func (db *DB) TransitionListingWithCleanup(id, currentListing, nextListing, rejectReason string) error {
+func (db *DB) TransitionListingWithCleanup(id, nextListing, rejectReason string) error {
 	tx, err := db.Begin()
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
+
+	var currentListing string
+	if err := tx.QueryRow("SELECT listing FROM apps WHERE id = ?", id).Scan(&currentListing); err != nil {
+		return err
+	}
 
 	if currentListing == "listed" && nextListing != "listed" {
 		if _, err := tx.Exec("DELETE FROM app_installations WHERE app_id = ?", id); err != nil {

--- a/internal/store/sqlite/app.go
+++ b/internal/store/sqlite/app.go
@@ -410,6 +410,11 @@ func (db *DB) DeleteInstallation(id string) error {
 	return err
 }
 
+func (db *DB) DeleteInstallationsByAppID(appID string) error {
+	_, err := db.Exec("DELETE FROM app_installations WHERE app_id = ?", appID)
+	return err
+}
+
 func (db *DB) CreateOAuthCode(code, appID, botID, state, codeChallenge string) error {
 	_, err := db.Exec(`INSERT INTO app_oauth_codes (code, app_id, bot_id, state, code_challenge) VALUES (?,?,?,?,?)`,
 		code, appID, botID, state, codeChallenge)

--- a/internal/store/sqlite/app.go
+++ b/internal/store/sqlite/app.go
@@ -415,6 +415,30 @@ func (db *DB) DeleteInstallationsByAppID(appID string) error {
 	return err
 }
 
+func (db *DB) TransitionListingWithCleanup(id, currentListing, nextListing, rejectReason string) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if currentListing == "listed" && nextListing != "listed" {
+		if _, err := tx.Exec("DELETE FROM app_installations WHERE app_id = ?", id); err != nil {
+			return err
+		}
+	}
+
+	reason := ""
+	if nextListing == "rejected" {
+		reason = rejectReason
+	}
+	if _, err := tx.Exec("UPDATE apps SET listing=?, listing_reject_reason=?, updated_at=? WHERE id=?", nextListing, reason, db.now(), id); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
 func (db *DB) CreateOAuthCode(code, appID, botID, state, codeChallenge string) error {
 	_, err := db.Exec(`INSERT INTO app_oauth_codes (code, app_id, bot_id, state, code_challenge) VALUES (?,?,?,?,?)`,
 		code, appID, botID, state, codeChallenge)

--- a/internal/store/sqlite/app.go
+++ b/internal/store/sqlite/app.go
@@ -226,6 +226,47 @@ func (db *DB) UpdateApp(id string, name, description, icon, iconURL, homepage, o
 	return err
 }
 
+func (db *DB) UpdateAppWithTransition(id string, update store.AppUpdate, nextListing string) (store.AppUpdateResult, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return store.AppUpdateResult{}, err
+	}
+	defer tx.Rollback()
+
+	var currentListing string
+	if err := tx.QueryRow("SELECT listing FROM apps WHERE id = ?", id).Scan(&currentListing); err != nil {
+		return store.AppUpdateResult{}, err
+	}
+
+	if _, err := tx.Exec(`UPDATE apps SET name=?, description=?, icon=?, icon_url=?, homepage=?,
+		tools=?, events=?, scopes=?, oauth_setup_url=?, oauth_redirect_url=?, webhook_url=?,
+		webhook_verified=CASE WHEN webhook_url <> ? THEN 0 ELSE webhook_verified END,
+		config_schema=?, version=?, readme=?, guide=?, updated_at=? WHERE id=?`,
+		update.Name, update.Description, update.Icon, update.IconURL, update.Homepage,
+		update.Tools, update.Events, update.Scopes, update.OAuthSetupURL, update.OAuthRedirectURL, update.WebhookURL,
+		update.WebhookURL, update.ConfigSchema, update.Version, update.Readme, update.Guide, db.now(), id,
+	); err != nil {
+		return store.AppUpdateResult{}, err
+	}
+
+	result := store.AppUpdateResult{Listing: currentListing}
+	if currentListing == "listed" && nextListing != "" && nextListing != "listed" {
+		if _, err := tx.Exec("DELETE FROM app_installations WHERE app_id = ?", id); err != nil {
+			return store.AppUpdateResult{}, err
+		}
+		if _, err := tx.Exec("UPDATE apps SET listing=?, listing_reject_reason='', updated_at=? WHERE id=?", nextListing, db.now(), id); err != nil {
+			return store.AppUpdateResult{}, err
+		}
+		result.Listing = nextListing
+		result.Transitioned = true
+	}
+
+	if err := tx.Commit(); err != nil {
+		return store.AppUpdateResult{}, err
+	}
+	return result, nil
+}
+
 func (db *DB) UpdateMarketplaceApp(id, name, description, iconURL, homepage, webhookURL, oauthSetupURL, oauthRedirectURL, version, readme, guide string, tools, events, scopes json.RawMessage) error {
 	_, err := db.Exec(`UPDATE apps SET name=?, description=?, icon_url=?, homepage=?,
 		webhook_url=?, oauth_setup_url=?, oauth_redirect_url=?, version=?, readme=?, guide=?,

--- a/internal/store/storetest/app_lifecycle.go
+++ b/internal/store/storetest/app_lifecycle.go
@@ -770,7 +770,7 @@ func TestAppLifecycle(t *testing.T, s store.Store) {
 		if err != nil {
 			t.Fatalf("InstallApp(cleanup): %v", err)
 		}
-		if err := s.TransitionListingWithCleanup(cleanupApp.ID, "listed", "unlisted", ""); err != nil {
+		if err := s.TransitionListingWithCleanup(cleanupApp.ID, "unlisted", ""); err != nil {
 			t.Fatalf("TransitionListingWithCleanup: %v", err)
 		}
 		got, err := s.GetApp(cleanupApp.ID)

--- a/internal/store/storetest/app_lifecycle.go
+++ b/internal/store/storetest/app_lifecycle.go
@@ -761,6 +761,41 @@ func TestAppLifecycle(t *testing.T, s store.Store) {
 		s.DeleteApp(setApp.ID)
 	})
 
+	t.Run("TransitionListingWithCleanup", func(t *testing.T) {
+		cleanupApp := mustCreateApp(t, s, u.ID, "Cleanup Test App", "cleanup-test-app")
+		if err := s.SetListing(cleanupApp.ID, "listed"); err != nil {
+			t.Fatalf("SetListing(listed): %v", err)
+		}
+		inst, err := s.InstallApp(cleanupApp.ID, b.ID)
+		if err != nil {
+			t.Fatalf("InstallApp(cleanup): %v", err)
+		}
+		if err := s.TransitionListingWithCleanup(cleanupApp.ID, "listed", "unlisted", ""); err != nil {
+			t.Fatalf("TransitionListingWithCleanup: %v", err)
+		}
+		got, err := s.GetApp(cleanupApp.ID)
+		if err != nil {
+			t.Fatalf("GetApp(cleanup): %v", err)
+		}
+		if got.Listing != "unlisted" {
+			t.Errorf("listing = %q, want %q", got.Listing, "unlisted")
+		}
+		if got.ListingRejectReason != "" {
+			t.Errorf("listing_reject_reason = %q, want empty", got.ListingRejectReason)
+		}
+		insts, err := s.ListInstallationsByApp(cleanupApp.ID)
+		if err != nil {
+			t.Fatalf("ListInstallationsByApp(cleanup): %v", err)
+		}
+		if len(insts) != 0 {
+			t.Fatalf("expected installations to be removed, got %d", len(insts))
+		}
+		if _, err := s.GetInstallation(inst.ID); err == nil {
+			t.Fatal("expected installation lookup to fail after cleanup")
+		}
+		s.DeleteApp(cleanupApp.ID)
+	})
+
 	t.Run("ListListedApps", func(t *testing.T) {
 		apps, err := s.ListListedApps()
 		if err != nil {

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
+import { invalidateAllAppQueries } from "@/hooks/use-apps";
 
 // ── Queries ──────────────────────────────────────────────
 
@@ -110,10 +111,7 @@ export function useSetAppListing() {
       api.setAppListing(id, listing),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.admin.apps() });
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
-      qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
-      qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
+      invalidateAllAppQueries(qc);
     },
   });
 }
@@ -126,10 +124,7 @@ export function useReviewListing() {
     onSuccess: (_data, { appId }) => {
       qc.invalidateQueries({ queryKey: queryKeys.admin.apps() });
       qc.invalidateQueries({ queryKey: queryKeys.apps.reviews(appId) });
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
-      qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
-      qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
+      invalidateAllAppQueries(qc);
     },
   });
 }
@@ -140,10 +135,7 @@ export function useDeleteAdminApp() {
     mutationFn: (id: string) => api.deleteApp(id),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.admin.apps() });
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
-      qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
-      qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
+      invalidateAllAppQueries(qc);
     },
   });
 }

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -108,7 +108,13 @@ export function useSetAppListing() {
   return useMutation({
     mutationFn: ({ id, listing }: { id: string; listing: string }) =>
       api.setAppListing(id, listing),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.admin.apps() }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.admin.apps() });
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+      qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
+      qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
+    },
   });
 }
 
@@ -120,6 +126,10 @@ export function useReviewListing() {
     onSuccess: (_data, { appId }) => {
       qc.invalidateQueries({ queryKey: queryKeys.admin.apps() });
       qc.invalidateQueries({ queryKey: queryKeys.apps.reviews(appId) });
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+      qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
+      qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
     },
   });
 }
@@ -128,7 +138,13 @@ export function useDeleteAdminApp() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => api.deleteApp(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.admin.apps() }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.admin.apps() });
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+      qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
+      qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
+    },
   });
 }
 

--- a/web/src/hooks/use-apps.ts
+++ b/web/src/hooks/use-apps.ts
@@ -1,6 +1,18 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, QueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
+
+/** Invalidate all app-related queries after install/uninstall/create/delete/delist operations. */
+export function invalidateAllAppQueries(qc: QueryClient, botId?: string) {
+  qc.invalidateQueries({ queryKey: ["apps"] });
+  qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
+  qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+  qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
+  qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
+  if (botId) {
+    qc.invalidateQueries({ queryKey: queryKeys.bots.apps(botId) });
+  }
+}
 
 export function useApps(opts?: { listing?: string }) {
   return useQuery({
@@ -54,7 +66,12 @@ export function useDeleteApp() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => api.deleteApp(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["apps"] }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["apps"] });
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
+      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+      qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
+    },
   });
 }
 

--- a/web/src/hooks/use-apps.ts
+++ b/web/src/hooks/use-apps.ts
@@ -58,7 +58,7 @@ export function useCreateApp() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (data: any) => api.createApp(data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["apps"] }),
+    onSuccess: () => invalidateAllAppQueries(qc),
   });
 }
 
@@ -66,12 +66,7 @@ export function useDeleteApp() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => api.deleteApp(id),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["apps"] });
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
-      qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
-    },
+    onSuccess: () => invalidateAllAppQueries(qc),
   });
 }
 
@@ -81,13 +76,7 @@ export function useInstallApp() {
     mutationFn: ({ appId, data }: { appId: string; data: any }) => api.installApp(appId, data),
     onSuccess: (_data, { appId, data }) => {
       qc.invalidateQueries({ queryKey: queryKeys.apps.installations(appId) });
-      qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
-      if (data?.bot_id) {
-        qc.invalidateQueries({ queryKey: queryKeys.bots.apps(data.bot_id) });
-      }
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
-      qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
+      invalidateAllAppQueries(qc, data?.bot_id);
     },
   });
 }
@@ -99,10 +88,7 @@ export function useUninstallApp() {
       api.deleteInstallation(appId, instId),
     onSuccess: (_data, { appId }) => {
       qc.invalidateQueries({ queryKey: queryKeys.apps.installations(appId) });
-      qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
-      qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
-      qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
+      invalidateAllAppQueries(qc);
     },
   });
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -71,6 +71,7 @@ createRoot(document.getElementById("root")!).render(
 
                 {/* Developer */}
                 <Route path="developer/apps" element={<DeveloperAppsPage />} />
+                <Route path="developer/apps/:id" element={<AppDetailPage />} />
 
                 {/* Domain 4: Management & Ops */}
                 <Route path="admin" element={<Navigate to="/dashboard/admin/overview" replace />} />

--- a/web/src/pages/app-detail.tsx
+++ b/web/src/pages/app-detail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useParams, Link, useNavigate } from "react-router-dom";
+import { useParams, Link, useNavigate, useLocation } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeft,
@@ -62,14 +62,18 @@ const NAV_SECTIONS = [
 export function AppDetailPage() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const { data: app, isError } = useApp(id!);
   const [section, setSection] = useState<SectionKey>("basic-info");
 
+  const isDeveloper = location.pathname.startsWith("/dashboard/developer/");
+  const backPath = isDeveloper ? "/dashboard/developer/apps" : "/dashboard/apps";
+
   // Convenience: invalidate app detail cache after mutations
   const refreshApp = () => queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(id!) });
 
-  if (isError) { navigate("/dashboard/apps"); return null; }
+  if (isError) { navigate(backPath); return null; }
   if (!app) return null;
 
   return (
@@ -77,7 +81,7 @@ export function AppDetailPage() {
       {/* Header */}
       <div className="flex items-center gap-3">
         <Link
-          to="/dashboard/apps"
+          to={backPath}
           className="text-muted-foreground hover:text-foreground"
           aria-label="返回我的应用"
         >
@@ -146,7 +150,7 @@ export function AppDetailPage() {
 
         <div className="flex-1 min-w-0">
           {section === "basic-info" && (
-            <BasicInfoSection key={app.updated_at} app={app} onUpdate={refreshApp} />
+            <BasicInfoSection key={app.updated_at} app={app} onUpdate={refreshApp} backPath={backPath} />
           )}
           {section === "install-app" && <InstallAppSection appId={id!} />}
           {section === "distribution" && <DistributionSection app={app} onUpdate={refreshApp} />}
@@ -165,8 +169,9 @@ export function AppDetailPage() {
 
 // ==================== Basic Information (merged Settings + Credentials) ====================
 
-function BasicInfoSection({ app, onUpdate }: { app: any; onUpdate: () => void }) {
+function BasicInfoSection({ app, onUpdate, backPath }: { app: any; onUpdate: () => void; backPath: string }) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { confirm, ConfirmDialog } = useConfirm();
   const [form, setForm] = useState({
     name: app.name || "",
@@ -206,7 +211,10 @@ function BasicInfoSection({ app, onUpdate }: { app: any; onUpdate: () => void })
     if (!ok) return;
     try {
       await api.deleteApp(app.id);
-      navigate("/dashboard/apps");
+      queryClient.invalidateQueries({ queryKey: ["apps"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+      navigate(backPath);
     } catch {}
   }
 
@@ -471,6 +479,7 @@ function InstallAppSection({ appId }: { appId: string }) {
   const [installing, setInstalling] = useState(false);
   const { toast } = useToast();
   const { confirm, ConfirmDialog } = useConfirm();
+  const queryClient = useQueryClient();
 
   async function load() {
     try {
@@ -513,6 +522,10 @@ function InstallAppSection({ appId }: { appId: string }) {
       await api.deleteInstallation(appId, instId);
       toast({ title: "已卸载" });
       load();
+      queryClient.invalidateQueries({ queryKey: queryKeys.bots.all() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
     } catch (e: any) {
       toast({ variant: "destructive", title: "卸载失败", description: e.message });
     }

--- a/web/src/pages/app-detail.tsx
+++ b/web/src/pages/app-detail.tsx
@@ -25,7 +25,7 @@ import { Input } from "../components/ui/input";
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from "../components/ui/card";
 import { Badge } from "../components/ui/badge";
 import { api, botDisplayName } from "../lib/api";
-import { useApp } from "@/hooks/use-apps";
+import { invalidateAllAppQueries, useApp } from "@/hooks/use-apps";
 import { queryKeys } from "@/lib/query-keys";
 import { useToast } from "@/hooks/use-toast";
 import { useConfirm } from "@/components/ui/confirm-dialog";
@@ -211,9 +211,8 @@ function BasicInfoSection({ app, onUpdate, backPath }: { app: any; onUpdate: () 
     if (!ok) return;
     try {
       await api.deleteApp(app.id);
-      queryClient.invalidateQueries({ queryKey: ["apps"] });
-      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+      invalidateAllAppQueries(queryClient);
+      queryClient.removeQueries({ queryKey: queryKeys.apps.detail(app.id) });
       navigate(backPath);
     } catch {}
   }
@@ -504,6 +503,7 @@ function InstallAppSection({ appId }: { appId: string }) {
       toast({ title: "安装成功" });
       setHandle("");
       load();
+      invalidateAllAppQueries(queryClient, botId);
     } catch (e: any) {
       toast({ variant: "destructive", title: "安装失败", description: e.message });
     }
@@ -522,10 +522,7 @@ function InstallAppSection({ appId }: { appId: string }) {
       await api.deleteInstallation(appId, instId);
       toast({ title: "已卸载" });
       load();
-      queryClient.invalidateQueries({ queryKey: queryKeys.bots.all() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
+      invalidateAllAppQueries(queryClient);
     } catch (e: any) {
       toast({ variant: "destructive", title: "卸载失败", description: e.message });
     }

--- a/web/src/pages/developer-apps.tsx
+++ b/web/src/pages/developer-apps.tsx
@@ -44,7 +44,7 @@ export function DeveloperAppsPage() {
       onSuccess: (app: any) => {
         setDialogOpen(false);
         setNewName("");
-        navigate(`/dashboard/apps/${app.id}`);
+        navigate(`/dashboard/developer/apps/${app.id}`);
       },
       onError: (e) => toast({ variant: "destructive", title: "创建失败", description: e.message }),
     });
@@ -104,7 +104,7 @@ export function DeveloperAppsPage() {
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
-                  navigate(`/dashboard/apps/${app.id}`);
+                  navigate(`/dashboard/developer/apps/${app.id}`);
                 }
               }}
             >

--- a/web/src/pages/developer-apps.tsx
+++ b/web/src/pages/developer-apps.tsx
@@ -100,7 +100,7 @@ export function DeveloperAppsPage() {
               role="button"
               tabIndex={0}
               className="group flex items-center gap-4 px-4 py-3.5 bg-card hover:bg-muted/40 transition-colors cursor-pointer"
-              onClick={() => navigate(`/dashboard/apps/${app.id}`)}
+              onClick={() => navigate(`/dashboard/developer/apps/${app.id}`)}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();

--- a/web/src/pages/install-app.tsx
+++ b/web/src/pages/install-app.tsx
@@ -18,7 +18,7 @@ import { Skeleton } from "../components/ui/skeleton";
 import { Label } from "../components/ui/label";
 import { useQueryClient } from "@tanstack/react-query";
 import { api, botDisplayName } from "../lib/api";
-import { useApp } from "@/hooks/use-apps";
+import { invalidateAllAppQueries, useApp } from "@/hooks/use-apps";
 import { useBots } from "@/hooks/use-bots";
 import { useToast } from "@/hooks/use-toast";
 import { queryKeys } from "@/lib/query-keys";
@@ -34,13 +34,7 @@ export function InstallAppPage() {
   const navigate = useNavigate();
   const { toast } = useToast();
   const qc = useQueryClient();
-  const invalidateAppQueries = () => {
-    qc.invalidateQueries({ queryKey: queryKeys.bots.apps(botId!) });
-    qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
-    qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
-    qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
-    qc.invalidateQueries({ queryKey: ["apps"] });
-  };
+  const invalidateAppQueries = () => invalidateAllAppQueries(qc, botId);
   const { data: app, isLoading: appLoading } = useApp(appId!);
   const { data: allBots = [] } = useBots();
   const bot = allBots.find((b: any) => b.id === botId);

--- a/web/src/pages/install-app.tsx
+++ b/web/src/pages/install-app.tsx
@@ -39,7 +39,7 @@ export function InstallAppPage() {
     qc.invalidateQueries({ queryKey: queryKeys.bots.all() });
     qc.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
     qc.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
-    qc.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
+    qc.invalidateQueries({ queryKey: ["apps"] });
   };
   const { data: app, isLoading: appLoading } = useApp(appId!);
   const { data: allBots = [] } = useBots();
@@ -144,7 +144,11 @@ export function InstallAppPage() {
       invalidateAppQueries();
       navigate(`/dashboard/accounts/${botId}/apps/${installationId}`);
     } catch (e: any) {
-      toast({ variant: "destructive", title: "安装失败", description: e.message });
+      const description =
+        e.message === "HTTP 403" && app?.homepage
+          ? `远端应用返回了 403。请先检查该应用的接入配置，或前往应用主页联系开发者：${app.homepage}`
+          : e.message;
+      toast({ variant: "destructive", title: "安装失败", description });
     } finally {
       setInstalling(false);
     }

--- a/web/src/pages/installation-detail.tsx
+++ b/web/src/pages/installation-detail.tsx
@@ -46,8 +46,9 @@ import { Label } from "../components/ui/label";
 import { api, botDisplayName } from "../lib/api";
 import { useBotApps, useBots } from "@/hooks/use-bots";
 import { useApp } from "@/hooks/use-apps";
-import { useQueryClient } from "@tanstack/react-query";
+import { QueryClient, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/query-keys";
+import { invalidateAllAppQueries } from "@/hooks/use-apps";
 import { SCOPE_DESCRIPTIONS, EVENT_TYPES } from "../lib/constants";
 import { useToast } from "@/hooks/use-toast";
 import { AppIcon } from "../components/app-icon";
@@ -743,7 +744,7 @@ function AppConfigForm({ app, inst, onUpdate }: { app: any; inst: any; onUpdate:
 
 // ==================== Config Section ====================
 
-function ConfigSection({ inst, onUninstall, queryClient }: { inst: any; onUninstall: () => void; queryClient: any }) {
+function ConfigSection({ inst, onUninstall, queryClient }: { inst: any; onUninstall: () => void; queryClient: QueryClient }) {
   const { toast } = useToast();
   const [showUninstallDialog, setShowUninstallDialog] = useState(false);
   const [uninstalling, setUninstalling] = useState(false);
@@ -753,11 +754,7 @@ function ConfigSection({ inst, onUninstall, queryClient }: { inst: any; onUninst
     try {
       await api.deleteInstallation(inst.app_id, inst.id);
       toast({ title: "已卸载" });
-      queryClient.invalidateQueries({ queryKey: queryKeys.bots.apps(inst.bot_id) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.bots.all() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
+      invalidateAllAppQueries(queryClient, inst.bot_id);
       onUninstall();
     } catch (e: any) {
       toast({ variant: "destructive", title: "卸载失败", description: e.message });

--- a/web/src/pages/installation-detail.tsx
+++ b/web/src/pages/installation-detail.tsx
@@ -19,6 +19,7 @@ import {
   ChevronRight,
   ShieldCheck,
   Zap,
+  ExternalLink,
 } from "lucide-react";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
@@ -217,6 +218,17 @@ export function InstallationDetailPage() {
                   内置应用
                 </Badge>
               ) : null}
+              {app.homepage && app.registry ? (
+                <a
+                  href={app.homepage}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                >
+                  <ExternalLink className="h-3 w-3" />
+                  应用主页
+                </a>
+              ) : null}
               <div className="flex items-center gap-2">
                 <Switch
                   checked={enabled}
@@ -314,6 +326,7 @@ export function InstallationDetailPage() {
             <ConfigSection
               inst={inst}
               onUninstall={() => navigate(`/dashboard/accounts/${botId}`)}
+              queryClient={queryClient}
             />
           )}
           {section === "event-logs" && (
@@ -725,7 +738,7 @@ function AppConfigForm({ app, inst, onUpdate }: { app: any; inst: any; onUpdate:
 
 // ==================== Config Section ====================
 
-function ConfigSection({ inst, onUninstall }: { inst: any; onUninstall: () => void }) {
+function ConfigSection({ inst, onUninstall, queryClient }: { inst: any; onUninstall: () => void; queryClient: any }) {
   const { toast } = useToast();
   const [showUninstallDialog, setShowUninstallDialog] = useState(false);
   const [uninstalling, setUninstalling] = useState(false);
@@ -735,6 +748,11 @@ function ConfigSection({ inst, onUninstall }: { inst: any; onUninstall: () => vo
     try {
       await api.deleteInstallation(inst.app_id, inst.id);
       toast({ title: "已卸载" });
+      queryClient.invalidateQueries({ queryKey: queryKeys.bots.apps(inst.bot_id) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.bots.all() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.apps() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.builtin() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.apps.all({ listing: "listed" }) });
       onUninstall();
     } catch (e: any) {
       toast({ variant: "destructive", title: "卸载失败", description: e.message });
@@ -845,6 +863,17 @@ function EventLogsSection({
           刷新
         </Button>
       </div>
+
+      {/* Show hint when logs contain 403/4xx errors */}
+      {!loading && logs.some((l) => {
+        const code = l.status_code || l.status;
+        return code >= 400 && code < 500;
+      }) && (
+        <div className="rounded-lg border border-orange-200 bg-orange-50 dark:border-orange-900 dark:bg-orange-950/30 p-3 text-xs text-muted-foreground space-y-1">
+          <p className="font-medium text-orange-700 dark:text-orange-400">部分事件投递失败</p>
+          <p>如果应用来自远程市场，4xx 错误通常是远程应用服务器的配置问题。请联系应用开发者确认 Webhook 地址和权限配置是否正确。</p>
+        </div>
+      )}
 
       <Card className="overflow-hidden">
         {loading ? (

--- a/web/src/pages/installation-detail.tsx
+++ b/web/src/pages/installation-detail.tsx
@@ -330,7 +330,12 @@ export function InstallationDetailPage() {
             />
           )}
           {section === "event-logs" && (
-            <EventLogsSection appId={inst.app_id} instId={inst.id} botId={botId!} />
+            <EventLogsSection
+              appId={inst.app_id}
+              instId={inst.id}
+              botId={botId!}
+              homepage={app.homepage}
+            />
           )}
           {section === "api-logs" && <ApiLogsSection appId={inst.app_id} instId={inst.id} />}
         </div>
@@ -810,10 +815,12 @@ function EventLogsSection({
   appId,
   instId,
   botId,
+  homepage,
 }: {
   appId: string;
   instId: string;
   botId: string;
+  homepage?: string;
 }) {
   const navigate = useNavigate();
   const [logs, setLogs] = useState<any[]>([]);
@@ -872,6 +879,17 @@ function EventLogsSection({
         <div className="rounded-lg border border-orange-200 bg-orange-50 dark:border-orange-900 dark:bg-orange-950/30 p-3 text-xs text-muted-foreground space-y-1">
           <p className="font-medium text-orange-700 dark:text-orange-400">部分事件投递失败</p>
           <p>如果应用来自远程市场，4xx 错误通常是远程应用服务器的配置问题。请联系应用开发者确认 Webhook 地址和权限配置是否正确。</p>
+          {homepage ? (
+            <a
+              href={homepage}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-orange-700 hover:underline dark:text-orange-400"
+            >
+              <ExternalLink className="h-3 w-3" />
+              前往应用主页
+            </a>
+          ) : null}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- fix developer app navigation so it stays within the developer route
- unify app-related query invalidation after create/install/uninstall/delete flows
- improve remote marketplace install failure guidance and event-log contact entry
- fix marketplace installed status to be computed per current user and add regression coverage

## Issue
Closes #205

## Validation
- pnpm --dir web type-check
- pnpm --dir web test --run
- go test ./internal/api -run 'TestMarketplaceInstalledStatusIsPerUser|TestAppLifecycle|TestAppInstall|TestSetBotAIModel'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user app installation status in the marketplace
  * App homepage links on installation detail pages
  * Developer-specific app detail route and improved back-navigation

* **Bug Fixes**
  * Admin listing changes now remove related app installations when unlisting/rejecting
  * Updating a listed app with semantically equivalent data no longer unlists it

* **Improvements**
  * Centralized, broader cache invalidation for app-related views
  * Improved install-failure messaging and event-log warnings linking to app homepages

* **Tests**
  * Added tests for per-user install visibility and listing-transition cleanup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->