### PR TITLE
fix: guard passkey registration with secure context check

### DIFF
--- a/web/src/pages/settings.tsx
+++ b/web/src/pages/settings.tsx
@@ -476,6 +476,7 @@ function PasskeySection() {
   const [success, setSuccess] = useState("");
   const [showXiaomiGuide, setShowXiaomiGuide] = useState(false);
   const { confirm, ConfirmDialog } = useConfirm();
+  const supportsPasskey = typeof window !== "undefined" && "PublicKeyCredential" in window;
 
   async function handleAdd() {
     if (isXiaomiDevice() && !showXiaomiGuide) {
@@ -530,7 +531,7 @@ function PasskeySection() {
             使用生物识别（指纹、Face ID）或安全密钥进行登录，更安全、更快捷。
           </CardDescription>
         </div>
-        <Button size="sm" onClick={handleAdd} disabled={adding} className="h-9">
+        <Button size="sm" onClick={handleAdd} disabled={adding || !supportsPasskey} className="h-9" title={supportsPasskey ? undefined : "需要 HTTPS 安全连接才能使用通行密钥"}>
           {adding ? (
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
           ) : (
@@ -549,6 +550,12 @@ function PasskeySection() {
         {success ? (
           <div className="text-xs p-3 rounded-lg bg-green-500/5 text-green-600 border border-green-500/10">
             {success}
+          </div>
+        ) : null}
+
+        {!supportsPasskey ? (
+          <div className="text-xs p-3 rounded-lg bg-amber-500/5 text-amber-700 dark:text-amber-400 border border-amber-500/10">
+            当前环境不支持通行密钥。请通过 HTTPS 安全连接访问后再试。
           </div>
         ) : null}
 

--- a/web/src/pages/settings.tsx
+++ b/web/src/pages/settings.tsx
@@ -479,6 +479,7 @@ function PasskeySection() {
   const supportsPasskey = typeof window !== "undefined" && "PublicKeyCredential" in window;
 
   async function handleAdd() {
+    if (!supportsPasskey) return;
     if (isXiaomiDevice() && !showXiaomiGuide) {
       setShowXiaomiGuide(true);
       return;
@@ -554,7 +555,7 @@ function PasskeySection() {
         ) : null}
 
         {!supportsPasskey ? (
-          <div className="text-xs p-3 rounded-lg bg-amber-500/5 text-amber-700 dark:text-amber-400 border border-amber-500/10">
+          <div className="text-xs p-3 rounded-lg bg-amber-500/5 text-amber-700 dark:text-amber-400 border border-amber-500/15">
             当前环境不支持通行密钥。请通过 HTTPS 安全连接访问后再试。
           </div>
         ) : null}


### PR DESCRIPTION
## Summary
- Settings page called `navigator.credentials.create()` without checking WebAuthn API availability
- WebAuthn API only exists in secure contexts (HTTPS or localhost), causing `Cannot read properties of undefined (reading 'create')` for HTTP users
- Add `supportsPasskey` check (same pattern as `login.tsx`), disable button + show HTTPS hint when unavailable

Closes #207

## Test plan
- [ ] Access settings page via HTTP — button should be disabled, amber hint visible
- [ ] Access settings page via HTTPS — button works normally, no hint shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Passkey registration now detects when the current environment doesn't support passkeys and shows a warning banner. The register button is disabled when passkeys are unavailable or a registration is in progress, with a tooltip explaining the HTTPS requirement for passkeys. This prevents failed registration attempts and improves guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->