### PR TITLE
fix: adjust scan login hint when registration is disabled (#176)

### DIFF
--- a/internal/api/auth_scan.go
+++ b/internal/api/auth_scan.go
@@ -165,7 +165,7 @@ func (s *Server) completeScanLogin(result *provider.BindPollResult, sendEvent fu
 		// Check registration gate (always allow first user for bootstrap)
 		count, _ := s.Store.UserCount()
 		if count > 0 && !s.registrationEnabled() {
-			sendEvent("error", `{"message":"registration is disabled"}`)
+			sendEvent("error", `{"message":"当前未开放注册，仅限已有账号扫码登录"}`)
 			return
 		}
 		suffix := creds.BotID

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -262,7 +262,9 @@ export function LoginPage() {
                 <p className="text-xs text-muted-foreground max-w-[260px] mx-auto leading-relaxed">
                   {scanStatus === "scanned"
                     ? "请在手机上确认登录"
-                    : "打开微信，扫描二维码即可登录。首次使用会自动创建账号并绑定 Bot。"}
+                    : registrationEnabled
+                      ? "打开微信，扫描二维码即可登录。首次使用会自动创建账号并绑定 Bot。"
+                      : "打开微信，扫描二维码即可登录。仅限已绑定的微信账号。"}
                 </p>
               </div>
 

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -262,9 +262,11 @@ export function LoginPage() {
                 <p className="text-xs text-muted-foreground max-w-[260px] mx-auto leading-relaxed">
                   {scanStatus === "scanned"
                     ? "请在手机上确认登录"
-                    : registrationEnabled
-                      ? "打开微信，扫描二维码即可登录。首次使用会自动创建账号并绑定 Bot。"
-                      : "打开微信，扫描二维码即可登录。仅限已绑定的微信账号。"}
+                    : !infoData
+                      ? "打开微信，扫描二维码即可登录。"
+                      : registrationEnabled
+                        ? "打开微信，扫描二维码即可登录。首次使用会自动创建账号并绑定 Bot。"
+                        : "打开微信，扫描二维码即可登录。仅限已绑定的微信账号。"}
                 </p>
               </div>
 


### PR DESCRIPTION
## Summary
- When registration is disabled, QR code hint now shows "仅限已绑定的微信账号" instead of "首次使用会自动创建账号并绑定 Bot"
- Backend already rejects new user scan-registration (`auth_scan.go:164-170`), this aligns frontend messaging
- Existing users can still scan-login normally

Closes #176

## Test plan
- [ ] Enable registration → QR hint says "首次使用会自动创建账号并绑定 Bot"
- [ ] Disable registration → QR hint says "仅限已绑定的微信账号"
- [ ] Scan with unregistered WeChat when registration disabled → error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * QR-code login instruction now varies correctly while scanning: shows a short “scan to login” placeholder, explains account creation when registrations are enabled, or indicates only pre-bound accounts can sign in when registrations are disabled.
  * Scan-login error message clarified when registration is closed, informing users that only existing bound accounts may log in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->