### PR TITLE
fix: auto-reconnect WebSocket on scan login/bind disconnect

### DIFF
--- a/internal/provider/ilink/bind.go
+++ b/internal/provider/ilink/bind.go
@@ -18,9 +18,11 @@ var PendingBinds = struct {
 }{M: make(map[string]*bindEntry)}
 
 type bindEntry struct {
-	client *ilinkSDK.Client
-	qrCode string
-	UserID string
+	client    *ilinkSDK.Client
+	qrCode    string
+	UserID    string
+	result    *provider.BindPollResult // cached terminal result for reconnecting clients
+	resultAt  time.Time
 }
 
 // StartBind initiates a QR code bind flow.
@@ -45,12 +47,18 @@ func StartBind(ctx context.Context, userID string) (sessionID, qrURL string, err
 }
 
 // PollBind checks the QR status. Returns a BindPollResult.
+// On "confirmed", the result is cached so reconnecting clients can retrieve it.
 func PollBind(ctx context.Context, sessionID string) (*provider.BindPollResult, error) {
 	PendingBinds.Lock()
 	entry, ok := PendingBinds.M[sessionID]
 	PendingBinds.Unlock()
 	if !ok {
 		return nil, fmt.Errorf("session not found")
+	}
+
+	// Return cached terminal result for reconnecting clients.
+	if entry.result != nil {
+		return entry.result, nil
 	}
 
 	status, err := entry.client.PollQRStatus(ctx, entry.qrCode)
@@ -88,12 +96,22 @@ func PollBind(ctx context.Context, sessionID string) (*provider.BindPollResult, 
 		}
 		credsJSON, _ := json.Marshal(creds)
 
-		// Cleanup
-		PendingBinds.Lock()
-		delete(PendingBinds.M, sessionID)
-		PendingBinds.Unlock()
+		result := &provider.BindPollResult{Status: "confirmed", Credentials: credsJSON}
 
-		return &provider.BindPollResult{Status: "confirmed", Credentials: credsJSON}, nil
+		// Cache the result instead of deleting — reconnecting clients need it.
+		// Schedule cleanup after 60s to avoid leaking memory.
+		entry.result = result
+		entry.resultAt = time.Now()
+		go func() {
+			time.Sleep(60 * time.Second)
+			PendingBinds.Lock()
+			if e, ok := PendingBinds.M[sessionID]; ok && e.result != nil {
+				delete(PendingBinds.M, sessionID)
+			}
+			PendingBinds.Unlock()
+		}()
+
+		return result, nil
 	default:
 		return &provider.BindPollResult{Status: status.Status}, nil
 	}

--- a/internal/provider/ilink/bind.go
+++ b/internal/provider/ilink/bind.go
@@ -18,11 +18,10 @@ var PendingBinds = struct {
 }{M: make(map[string]*bindEntry)}
 
 type bindEntry struct {
-	client    *ilinkSDK.Client
-	qrCode    string
-	UserID    string
-	result    *provider.BindPollResult // cached terminal result for reconnecting clients
-	resultAt  time.Time
+	client *ilinkSDK.Client
+	qrCode string
+	UserID string
+	result *provider.BindPollResult // cached terminal result for reconnecting clients
 }
 
 // StartBind initiates a QR code bind flow.
@@ -51,14 +50,15 @@ func StartBind(ctx context.Context, userID string) (sessionID, qrURL string, err
 func PollBind(ctx context.Context, sessionID string) (*provider.BindPollResult, error) {
 	PendingBinds.Lock()
 	entry, ok := PendingBinds.M[sessionID]
+	// Return cached terminal result for reconnecting clients (under lock).
+	if ok && entry.result != nil {
+		r := entry.result
+		PendingBinds.Unlock()
+		return r, nil
+	}
 	PendingBinds.Unlock()
 	if !ok {
 		return nil, fmt.Errorf("session not found")
-	}
-
-	// Return cached terminal result for reconnecting clients.
-	if entry.result != nil {
-		return entry.result, nil
 	}
 
 	status, err := entry.client.PollQRStatus(ctx, entry.qrCode)
@@ -98,16 +98,15 @@ func PollBind(ctx context.Context, sessionID string) (*provider.BindPollResult, 
 
 		result := &provider.BindPollResult{Status: "confirmed", Credentials: credsJSON}
 
-		// Cache the result instead of deleting — reconnecting clients need it.
+		// Cache the result under lock — reconnecting clients need it.
 		// Schedule cleanup after 60s to avoid leaking memory.
+		PendingBinds.Lock()
 		entry.result = result
-		entry.resultAt = time.Now()
+		PendingBinds.Unlock()
 		go func() {
 			time.Sleep(60 * time.Second)
 			PendingBinds.Lock()
-			if e, ok := PendingBinds.M[sessionID]; ok && e.result != nil {
-				delete(PendingBinds.M, sessionID)
-			}
+			delete(PendingBinds.M, sessionID)
 			PendingBinds.Unlock()
 		}()
 

--- a/web/src/pages/bots.tsx
+++ b/web/src/pages/bots.tsx
@@ -54,6 +54,16 @@ export function BotsPage() {
   const [qrUrl, setQrUrl] = useState("");
   const [bindStatus, setBindStatus] = useState("");
   const navigate = useNavigate();
+  const bindWsRef = useRef<WebSocket | null>(null);
+  const bindTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Cleanup WS/timer when dialog closes or component unmounts
+  useEffect(() => {
+    return () => {
+      if (bindTimerRef.current) clearTimeout(bindTimerRef.current);
+      if (bindWsRef.current) bindWsRef.current.close();
+    };
+  }, []);
 
   async function startBind() {
     setBinding(true);
@@ -74,10 +84,10 @@ export function BotsPage() {
     const ws = new WebSocket(
       `${protocol}//${window.location.host}/api/bots/bind/status/${sessionID}`,
     );
+    bindWsRef.current = ws;
     let settled = false;
 
     ws.onmessage = (e) => {
-      retries = 0;
       const data = JSON.parse(e.data);
       if (data.event === "status") {
         if (data.status === "scanned") setBindStatus("已扫码，请在手机上点击确认...");
@@ -103,7 +113,7 @@ export function BotsPage() {
       if (retries < MAX_RETRIES) {
         const delay = Math.min(1000 * 2 ** retries, 8000);
         setBindStatus("连接中断，正在重连...");
-        setTimeout(() => connectBindWS(sessionID, retries + 1), delay);
+        bindTimerRef.current = setTimeout(() => connectBindWS(sessionID, retries + 1), delay);
       } else {
         setBindStatus("连接中断，请重试");
         setBinding(false);

--- a/web/src/pages/bots.tsx
+++ b/web/src/pages/bots.tsx
@@ -62,37 +62,53 @@ export function BotsPage() {
       const { session_id, qr_url } = await api.bindStart();
       setQrUrl(qr_url);
       setBindStatus("请使用手机微信扫描上方二维码");
-      const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-      const ws = new WebSocket(
-        `${protocol}//${window.location.host}/api/bots/bind/status/${session_id}`,
-      );
-      ws.onmessage = (e) => {
-        const data = JSON.parse(e.data);
-        if (data.event === "status") {
-          if (data.status === "scanned") setBindStatus("已扫码，请在手机上点击确认...");
-          if (data.status === "refreshed") {
-            setQrUrl(data.qr_url);
-            setBindStatus("二维码已刷新");
-          }
-          if (data.status === "connected") {
-            ws.close();
-            setBinding(false);
-            navigate(
-              data.is_new && data.bot_id
-                ? `/dashboard/onboarding?bot_id=${data.bot_id}`
-                : "/dashboard/accounts",
-            );
-          }
-        }
-      };
-      ws.onerror = () => {
-        setBindStatus("同步中断，请重试");
-        ws.close();
-      };
-      ws.onclose = () => {};
+      connectBindWS(session_id);
     } catch (err: any) {
       setBindStatus("初始化失败: " + err.message);
     }
+  }
+
+  function connectBindWS(sessionID: string, retries = 0) {
+    const MAX_RETRIES = 5;
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const ws = new WebSocket(
+      `${protocol}//${window.location.host}/api/bots/bind/status/${sessionID}`,
+    );
+    let settled = false;
+
+    ws.onmessage = (e) => {
+      retries = 0;
+      const data = JSON.parse(e.data);
+      if (data.event === "status") {
+        if (data.status === "scanned") setBindStatus("已扫码，请在手机上点击确认...");
+        if (data.status === "refreshed") {
+          setQrUrl(data.qr_url);
+          setBindStatus("二维码已刷新");
+        }
+        if (data.status === "connected") {
+          settled = true;
+          ws.close();
+          setBinding(false);
+          navigate(
+            data.is_new && data.bot_id
+              ? `/dashboard/onboarding?bot_id=${data.bot_id}`
+              : "/dashboard/accounts",
+          );
+        }
+      }
+    };
+    ws.onerror = () => { ws.close(); };
+    ws.onclose = () => {
+      if (settled) return;
+      if (retries < MAX_RETRIES) {
+        const delay = Math.min(1000 * 2 ** retries, 8000);
+        setBindStatus("连接中断，正在重连...");
+        setTimeout(() => connectBindWS(sessionID, retries + 1), delay);
+      } else {
+        setBindStatus("连接中断，请重试");
+        setBinding(false);
+      }
+    };
   }
 
   return (

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { KeyRound, Shield, User, Lock, ArrowRight, Loader2, Github, X, QrCode, ChevronDown } from "lucide-react";
 import { useNavigate, Link } from "react-router-dom";
 import QRCode from "qrcode";
@@ -44,6 +44,8 @@ export function LoginPage() {
   const [qrUrl, setQrUrl] = useState("");
   const [scanStatus, setScanStatus] = useState<"idle" | "loading" | "wait" | "scanned" | "error">("idle");
   const [scanMessage, setScanMessage] = useState("");
+  const scanWsRef = useRef<WebSocket | null>(null);
+  const scanTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Password login state
   const [mode, setMode] = useState<"login" | "register">("login");
@@ -66,9 +68,13 @@ export function LoginPage() {
     }
   }, [infoData]);
 
-  // Auto-start scan login on mount
+  // Auto-start scan login on mount; cleanup WS/timer on unmount
   useEffect(() => {
     startScanLogin();
+    return () => {
+      if (scanTimerRef.current) clearTimeout(scanTimerRef.current);
+      if (scanWsRef.current) scanWsRef.current.close();
+    };
   }, []);
 
   async function startScanLogin() {
@@ -99,10 +105,10 @@ export function LoginPage() {
     const MAX_RETRIES = 5;
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     const ws = new WebSocket(`${protocol}//${window.location.host}/api/auth/scan/status/${sessionID}`);
-    let settled = false; // true when login completes or a terminal error occurs
+    scanWsRef.current = ws;
+    let settled = false;
 
     ws.onmessage = (e) => {
-      retries = 0; // reset on successful message
       const d = JSON.parse(e.data);
       if (d.event === "status") {
         if (d.status === "wait") {
@@ -135,7 +141,7 @@ export function LoginPage() {
       if (retries < MAX_RETRIES) {
         const delay = Math.min(1000 * 2 ** retries, 8000);
         setScanMessage("连接中断，正在重连...");
-        setTimeout(() => connectScanWS(sessionID, retries + 1), delay);
+        scanTimerRef.current = setTimeout(() => connectScanWS(sessionID, retries + 1), delay);
       } else {
         setScanStatus("error");
         setScanMessage("连接中断，请刷新重试");

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState } from "react";
 import { KeyRound, Shield, User, Lock, ArrowRight, Loader2, Github, X, QrCode, ChevronDown } from "lucide-react";
 import { useNavigate, Link } from "react-router-dom";
 import QRCode from "qrcode";

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -88,43 +88,59 @@ export function LoginPage() {
       setScanStatus("wait");
       setScanMessage("请使用微信扫描二维码");
 
-      const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-      const ws = new WebSocket(`${protocol}//${window.location.host}/api/auth/scan/status/${data.session_id}`);
-      ws.onmessage = (e) => {
-        const d = JSON.parse(e.data);
-        if (d.event === "status") {
-          if (d.status === "wait") {
-            // keep waiting
-          } else if (d.status === "scanned") {
-            setScanStatus("scanned");
-            setScanMessage("已扫码，请在手机上确认...");
-          } else if (d.status === "refreshed") {
-            setQrUrl(d.qr_url);
-            setScanStatus("wait");
-            setScanMessage("二维码已刷新，请重新扫描");
-          } else if (d.status === "connected") {
-            if (d.session_token) {
-              document.cookie = `session=${d.session_token}; path=/; max-age=${7*24*3600}; samesite=lax`;
-            }
-            ws.close();
-            navigate(d.is_new && d.bot_id ? `/dashboard/onboarding?bot_id=${d.bot_id}` : "/dashboard");
-          }
-        } else if (d.event === "error") {
-          setScanMessage(d.message || "扫码登录失败");
-          setScanStatus("error");
-          ws.close();
-        }
-      };
-      ws.onerror = () => {
-        setScanStatus("error");
-        setScanMessage("连接中断，请刷新重试");
-        ws.close();
-      };
-      ws.onclose = () => {};
+      connectScanWS(data.session_id);
     } catch (err: any) {
       setScanStatus("error");
       setScanMessage(err.message || "初始化失败");
     }
+  }
+
+  function connectScanWS(sessionID: string, retries = 0) {
+    const MAX_RETRIES = 5;
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const ws = new WebSocket(`${protocol}//${window.location.host}/api/auth/scan/status/${sessionID}`);
+    let settled = false; // true when login completes or a terminal error occurs
+
+    ws.onmessage = (e) => {
+      retries = 0; // reset on successful message
+      const d = JSON.parse(e.data);
+      if (d.event === "status") {
+        if (d.status === "wait") {
+          // keep waiting
+        } else if (d.status === "scanned") {
+          setScanStatus("scanned");
+          setScanMessage("已扫码，请在手机上确认...");
+        } else if (d.status === "refreshed") {
+          setQrUrl(d.qr_url);
+          setScanStatus("wait");
+          setScanMessage("二维码已刷新，请重新扫描");
+        } else if (d.status === "connected") {
+          settled = true;
+          if (d.session_token) {
+            document.cookie = `session=${d.session_token}; path=/; max-age=${7*24*3600}; samesite=lax`;
+          }
+          ws.close();
+          navigate(d.is_new && d.bot_id ? `/dashboard/onboarding?bot_id=${d.bot_id}` : "/dashboard");
+        }
+      } else if (d.event === "error") {
+        settled = true;
+        setScanMessage(d.message || "扫码登录失败");
+        setScanStatus("error");
+        ws.close();
+      }
+    };
+    ws.onerror = () => { ws.close(); };
+    ws.onclose = () => {
+      if (settled) return;
+      if (retries < MAX_RETRIES) {
+        const delay = Math.min(1000 * 2 ** retries, 8000);
+        setScanMessage("连接中断，正在重连...");
+        setTimeout(() => connectScanWS(sessionID, retries + 1), delay);
+      } else {
+        setScanStatus("error");
+        setScanMessage("连接中断，请刷新重试");
+      }
+    };
   }
 
   // Password login


### PR DESCRIPTION
## Summary
- QR scan login and bot binding now auto-reconnect WebSocket on disconnect
- Exponential backoff: 1s → 2s → 4s → 8s, max 5 retries
- Shows "连接中断，正在重连..." during reconnection instead of a terminal error
- Backend session stays alive in PendingBinds, so reconnection resumes seamlessly
- Applied to both `login.tsx` (scan-to-login) and `bots.tsx` (bot binding)

Ref #176

## Test plan
- [ ] Start scan login, kill network briefly → should auto-reconnect and resume
- [ ] Start bot binding, kill network briefly → same behavior
- [ ] Kill network for >30s (exceed retries) → shows "连接中断，请刷新重试"
- [ ] Normal scan login flow → no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved connection stability in bot binding and login flows with automatic reconnection on unexpected disconnections.
  * Added capped exponential backoff retry (up to 5 attempts), clearer retry/status messages, and a "settled" safeguard to stop further retries after terminal events.
  * Ensure active connections and timers are cleaned up when leaving the page.
* **Bug Fixes**
  * Briefly persist confirmed binding results so reconnecting clients can pick up confirmed sessions without re-polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->