### PR TITLE
fix: handle null tool parameters and improve trace error visibility

### DIFF
--- a/internal/sink/ai.go
+++ b/internal/sink/ai.go
@@ -439,7 +439,7 @@ func (s *AI) collectTools(botID string) []ai.Tool {
 				continue
 			}
 			params := t.Parameters
-			if len(params) == 0 {
+			if len(params) == 0 || string(params) == "null" {
 				params = json.RawMessage(`{"type":"object","properties":{}}`)
 			}
 			// Use installation ID as prefix for unique routing

--- a/web/src/pages/bot-traces-tab.tsx
+++ b/web/src/pages/bot-traces-tab.tsx
@@ -91,8 +91,10 @@ export function BotTracesTab({ botId }: { botId: string }) {
                     <TableCell className="font-mono text-xs max-w-[120px] truncate">
                       {sender}
                     </TableCell>
-                    <TableCell className="text-xs text-muted-foreground truncate max-w-[200px]">
-                      {content}
+                    <TableCell className="text-xs text-muted-foreground truncate max-w-[200px]" title={root.status_code === "error" && root.status_message ? root.status_message : undefined}>
+                      {root.status_code === "error" && root.status_message ? (
+                        <span className="text-destructive">{root.status_message}</span>
+                      ) : content}
                     </TableCell>
                     <TableCell className="text-right font-mono text-[10px] text-muted-foreground">
                       {root.attributes?.["ai.tokens.total"] || "\u2014"}

--- a/web/src/pages/trace-detail/flow-view.tsx
+++ b/web/src/pages/trace-detail/flow-view.tsx
@@ -82,10 +82,16 @@ function SpanNodeComponent({ data }: { data: any }) {
           {span.kind}
         </Badge>
       </div>
-      <div className="text-[11px] font-mono font-medium truncate">{span.name}</div>
-      <div className="text-[9px] text-muted-foreground font-mono mt-0.5">
-        {formatDuration(dur)}
-      </div>
+      <div className="text-[11px] font-mono font-medium truncate" title={span.name}>{span.name}</div>
+      {span.status_code === "error" && span.status_message ? (
+        <div className="text-[9px] text-destructive font-mono mt-0.5 truncate" title={span.status_message}>
+          {span.status_message}
+        </div>
+      ) : (
+        <div className="text-[9px] text-muted-foreground font-mono mt-0.5">
+          {formatDuration(dur)}
+        </div>
+      )}
       <Handle type="source" position={Position.Bottom} className="!bg-muted-foreground !w-2 !h-2" />
     </div>
   );

--- a/web/src/pages/trace-detail/span-detail.tsx
+++ b/web/src/pages/trace-detail/span-detail.tsx
@@ -79,7 +79,7 @@ export function SpanDetail({ span, open, onClose }: SpanDetailProps) {
           </div>
           <SheetTitle className="font-mono text-sm truncate">{displaySpan.name}</SheetTitle>
           {displaySpan.status_message && (
-            <SheetDescription className="text-destructive text-xs">{displaySpan.status_message}</SheetDescription>
+            <SheetDescription className="text-destructive text-xs whitespace-pre-wrap break-words">{displaySpan.status_message}</SheetDescription>
           )}
         </SheetHeader>
 

--- a/web/src/pages/trace-detail/timeline-view.tsx
+++ b/web/src/pages/trace-detail/timeline-view.tsx
@@ -108,7 +108,7 @@ export function TimelineView({ spans, selectedSpanId, onSelectSpan }: TimelineVi
                   <div className="w-4 h-4 shrink-0" />
                 )}
                 <StatusIcon code={span.status_code} size="w-3 h-3" />
-                <span className="text-[11px] font-mono truncate ml-1">{span.name}</span>
+                <span className="text-[11px] font-mono truncate ml-1" title={span.status_code === "error" && span.status_message ? `❌ ${span.status_message}` : span.name}>{span.name}</span>
               </div>
             );
           })}


### PR DESCRIPTION
## Summary
- **AI API 400 修复**: 当 App 工具的 `parameters` 为 JSON `null` 时，`len(params) == 0` 检查遗漏了 4 字节的 `"null"` 字面量，导致无效 schema 发送给 AI API。现在同时检查 `string(params) == "null"` 并替换为合法的空 object schema。
- **链路追踪错误显示**: 侧边栏详情的错误信息增加自动换行，不再被截断；时间线视图悬停显示完整错误；流程图节点内联显示错误信息（红色）；追踪列表错误条目直接显示红色错误文本。

## Test plan
- [ ] 注册一个 `parameters` 为 `null` 的 App 工具，触发 AI 对话，确认不再返回 400
- [ ] 在链路追踪中触发一条错误 span，检查侧边栏能完整显示长错误信息
- [ ] 检查时间线视图中错误 span 悬停时的 tooltip
- [ ] 检查流程图中错误节点显示红色错误文本
- [ ] 检查追踪列表中错误条目显示红色错误信息

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error message visibility in trace views with better formatting and text wrapping.
  * Added error tooltips that appear when hovering over span nodes.

* **Style**
  * Enhanced error indicators with clearer destructive styling to distinguish error statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->