### PR TITLE
docs: warn when RP_ORIGIN is default and document reverse proxy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,17 @@ volumes:
 
 前面放个 Nginx / Caddy 做 HTTPS 反代就行。
 
+### 部署到反向代理 / PaaS（Zeabur / Railway / Render 等）
+
+只要 Hub 不是直接通过 `http://localhost:9800` 被访问，就**必须**设置 `RP_ORIGIN` 为浏览器实际访问的地址，否则应用授权（App OAuth）回调链接会跳回 `localhost:9800`，导致授权失败。
+
+```bash
+RP_ORIGIN=https://your-domain.example.com   # 必须带 scheme，不要带末尾 /
+RP_ID=your-domain.example.com               # WebAuthn / Passkey 用的域名
+```
+
+同理，如果开了对象存储且未设置 `STORAGE_PUBLIC_URL`，媒体 URL 也会基于 `RP_ORIGIN` 拼接，所以这个变量配对了一举两得。
+
 ### 从源码构建
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ RP_ORIGIN=https://your-domain.example.com   # 必须带 scheme，不要带末尾
 RP_ID=your-domain.example.com               # WebAuthn / Passkey 用的域名
 ```
 
-同理，如果开了对象存储且未设置 `STORAGE_PUBLIC_URL`，媒体 URL 也会基于 `RP_ORIGIN` 拼接，所以这个变量配对了一举两得。
+同理，如果开了对象存储且未设置 `STORAGE_PUBLIC_URL`，媒体 URL 也会基于 `RP_ORIGIN` 拼接，所以这个变量配对了一举两得。如果对象存储走的是独立的 CDN / 域名，请额外设置 `STORAGE_PUBLIC_URL`。
 
 ### 从源码构建
 

--- a/main.go
+++ b/main.go
@@ -79,6 +79,14 @@ func main() {
 
 	cfg := config.Parse()
 
+	// Warn if RP_ORIGIN is left at the default. OAuth callback URLs and
+	// storage public URLs are derived from it, so deployments behind a
+	// reverse proxy or on a public host must override it or app
+	// authorization links will point at localhost. See issue #216.
+	if cfg.RPOrigin == "http://localhost:9800" {
+		slog.Warn("RP_ORIGIN is using the default value; OAuth callbacks and media URLs will point at localhost. Set RP_ORIGIN to your public URL (e.g. https://hub.example.com) when deploying behind a reverse proxy or on a public host.")
+	}
+
 	// Ensure data directory exists for SQLite
 	if !strings.HasPrefix(cfg.DBPath, "postgres") {
 		if err := config.EnsureDataDir(); err != nil {


### PR DESCRIPTION
## Summary
- Add a startup `slog.Warn` when `RP_ORIGIN` is left at the default `http://localhost:9800`, since OAuth callbacks and media URLs are derived from it.
- Add a "部署到反向代理 / PaaS" subsection in the README explaining that `RP_ORIGIN` (and `RP_ID`) must be set when deploying to Zeabur / Railway / Render or behind any reverse proxy.

Refs #216 — user reported app authorization links pointed back at `localhost:9800` after deploying to Zeabur because `RP_ORIGIN` wasn't set.

## Test plan
- [x] `go build ./...` passes
- [ ] Run `oih` without `RP_ORIGIN` set → warning appears in logs
- [ ] Run `oih` with `RP_ORIGIN=https://example.com` → no warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deployment guidance for reverse proxy and PaaS platforms (Zeabur, Railway, Render, etc.) explaining environment variable configuration requirements.
  * Documented object storage URL configuration behavior.

* **Chores**
  * Added runtime warning when using default configuration values to alert operators of potential misconfigurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->