### PR TITLE
feat: support importing tools from MCP server

### DIFF
--- a/internal/api/mcp_import.go
+++ b/internal/api/mcp_import.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"time"
@@ -13,6 +15,16 @@ import (
 	"github.com/openilink/openilink-hub/internal/store"
 )
 
+const maxImportTools = 200
+
+var blockedHeaderKeys = map[string]bool{
+	"host":            true,
+	"content-type":    true,
+	"content-length":  true,
+	"transfer-encoding": true,
+	"connection":      true,
+}
+
 type mcpImportRequest struct {
 	URL     string            `json:"url"`
 	Headers map[string]string `json:"headers,omitempty"`
@@ -22,12 +34,16 @@ type mcpImportResult struct {
 	ServerName    string          `json:"server_name,omitempty"`
 	ServerVersion string          `json:"server_version,omitempty"`
 	Tools         []store.AppTool `json:"tools"`
+	Truncated     bool            `json:"truncated,omitempty"`
 }
 
-// POST /api/apps/import-mcp — discover tools from a remote MCP server
+// handleImportMCP discovers tools from a remote MCP server.
 func (s *Server) handleImportMCP(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+
+	body := http.MaxBytesReader(w, r.Body, 8*1024)
 	var req mcpImportRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(body).Decode(&req); err != nil {
 		jsonError(w, "invalid request", http.StatusBadRequest)
 		return
 	}
@@ -42,22 +58,64 @@ func (s *Server) handleImportMCP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	headers := filterHeaders(req.Headers)
+
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
 
-	result, err := discoverMCPTools(ctx, req.URL, req.Headers)
+	result, err := discoverMCPTools(ctx, s.Version, req.URL, headers)
 	if err != nil {
-		jsonError(w, "failed to connect to MCP server: "+err.Error(), http.StatusBadGateway)
+		slog.Warn("mcp import failed", "url", req.URL, "err", err)
+		jsonError(w, "failed to connect to MCP server", http.StatusBadGateway)
 		return
 	}
+
+	slog.Info("mcp import", "url", req.URL, "server", result.ServerName, "tools", len(result.Tools), "truncated", result.Truncated, "duration_ms", time.Since(start).Milliseconds())
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(result)
 }
 
-func discoverMCPTools(ctx context.Context, serverURL string, headers map[string]string) (*mcpImportResult, error) {
+func filterHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	filtered := make(map[string]string, len(headers))
+	for k, v := range headers {
+		lower := stringToLower(k)
+		if !blockedHeaderKeys[lower] {
+			filtered[k] = v
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
+}
+
+func stringToLower(s string) string {
+	b := make([]byte, len(s))
+	for i := range len(s) {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		b[i] = c
+	}
+	return string(b)
+}
+
+func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers map[string]string) (*mcpImportResult, error) {
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: ssrfSafeDialContext,
+			ResponseHeaderTimeout: 10 * time.Second,
+		},
+		Timeout: 15 * time.Second,
+	}
+
 	opts := []transport.StreamableHTTPCOption{
-		transport.WithHTTPTimeout(10 * time.Second),
+		transport.WithHTTPBasicClient(httpClient),
 	}
 	if len(headers) > 0 {
 		opts = append(opts, transport.WithHTTPHeaders(headers))
@@ -73,11 +131,16 @@ func discoverMCPTools(ctx context.Context, serverURL string, headers map[string]
 		return nil, err
 	}
 
+	version := hubVersion
+	if version == "" {
+		version = "dev"
+	}
+
 	initResult, err := c.Initialize(ctx, mcp.InitializeRequest{
 		Params: mcp.InitializeParams{
 			ClientInfo: mcp.Implementation{
 				Name:    "OpeniLink Hub",
-				Version: "1.0.0",
+				Version: version,
 			},
 			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
 		},
@@ -96,17 +159,22 @@ func discoverMCPTools(ctx context.Context, serverURL string, headers map[string]
 
 	toolsResult, err := c.ListTools(ctx, mcp.ListToolsRequest{})
 	if err != nil {
-		return result, nil
+		return nil, fmt.Errorf("list tools: %w", err)
 	}
 
-	for _, t := range toolsResult.Tools {
+	for i, t := range toolsResult.Tools {
+		if i >= maxImportTools {
+			result.Truncated = true
+			break
+		}
+
 		appTool := store.AppTool{
 			Name:        t.Name,
 			Description: t.Description,
 		}
 
-		params, _ := json.Marshal(t.InputSchema)
-		if len(params) > 0 && string(params) != `{"type":""}` && string(params) != `{"type":"object"}` {
+		params, err := json.Marshal(t.InputSchema)
+		if err == nil && len(params) > 0 && string(params) != `{"type":""}` && string(params) != `{"type":"object"}` {
 			appTool.Parameters = params
 		}
 
@@ -115,3 +183,4 @@ func discoverMCPTools(ctx context.Context, serverURL string, headers map[string]
 
 	return result, nil
 }
+

--- a/internal/api/mcp_import.go
+++ b/internal/api/mcp_import.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/openilink/openilink-hub/internal/store"
+)
+
+type mcpImportRequest struct {
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+type mcpImportResult struct {
+	ServerName    string          `json:"server_name,omitempty"`
+	ServerVersion string          `json:"server_version,omitempty"`
+	Tools         []store.AppTool `json:"tools"`
+}
+
+// POST /api/apps/import-mcp — discover tools from a remote MCP server
+func (s *Server) handleImportMCP(w http.ResponseWriter, r *http.Request) {
+	var req mcpImportRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if req.URL == "" {
+		jsonError(w, "url is required", http.StatusBadRequest)
+		return
+	}
+
+	u, err := url.ParseRequestURI(req.URL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		jsonError(w, "url must be a valid http or https URL", http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	result, err := discoverMCPTools(ctx, req.URL, req.Headers)
+	if err != nil {
+		jsonError(w, "failed to connect to MCP server: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+func discoverMCPTools(ctx context.Context, serverURL string, headers map[string]string) (*mcpImportResult, error) {
+	opts := []transport.StreamableHTTPCOption{
+		transport.WithHTTPTimeout(10 * time.Second),
+	}
+	if len(headers) > 0 {
+		opts = append(opts, transport.WithHTTPHeaders(headers))
+	}
+
+	c, err := client.NewStreamableHttpClient(serverURL, opts...)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+
+	if err := c.Start(ctx); err != nil {
+		return nil, err
+	}
+
+	initResult, err := c.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ClientInfo: mcp.Implementation{
+				Name:    "OpeniLink Hub",
+				Version: "1.0.0",
+			},
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := &mcpImportResult{
+		Tools: []store.AppTool{},
+	}
+	if initResult != nil {
+		result.ServerName = initResult.ServerInfo.Name
+		result.ServerVersion = initResult.ServerInfo.Version
+	}
+
+	toolsResult, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		return result, nil
+	}
+
+	for _, t := range toolsResult.Tools {
+		appTool := store.AppTool{
+			Name:        t.Name,
+			Description: t.Description,
+		}
+
+		params, _ := json.Marshal(t.InputSchema)
+		if len(params) > 0 && string(params) != `{"type":""}` && string(params) != `{"type":"object"}` {
+			appTool.Parameters = params
+		}
+
+		result.Tools = append(result.Tools, appTool)
+	}
+
+	return result, nil
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -174,6 +174,7 @@ func (s *Server) Handler() http.Handler {
 	protected.HandleFunc("DELETE /api/admin/users/{id}", s.requireAdmin(s.handleDeleteUser))
 
 	// --- Apps ---
+	protected.HandleFunc("POST /api/apps/import-mcp", s.handleImportMCP)
 	protected.HandleFunc("POST /api/apps", s.handleCreateApp)
 	protected.HandleFunc("GET /api/apps", s.handleListApps)
 	protected.HandleFunc("GET /api/apps/{id}", s.handleGetApp)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -198,6 +198,12 @@ export const api = {
   deleteAIConfig: () => request("/api/admin/config/ai", { method: "DELETE" }),
 
   // Apps
+  importMCP: (data: { url: string; headers?: Record<string, string> }) =>
+    request<{
+      server_name?: string;
+      server_version?: string;
+      tools: Array<{ name: string; description: string; command?: string; parameters?: any }>;
+    }>("/api/apps/import-mcp", { method: "POST", body: JSON.stringify(data) }),
   createApp: (data: any) =>
     request<any>("/api/apps", { method: "POST", body: JSON.stringify(data) }),
   listApps: (opts?: { listing?: string }) =>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -203,6 +203,7 @@ export const api = {
       server_name?: string;
       server_version?: string;
       tools: Array<{ name: string; description: string; command?: string; parameters?: any }>;
+      truncated?: boolean;
     }>("/api/apps/import-mcp", { method: "POST", body: JSON.stringify(data) }),
   createApp: (data: any) =>
     request<any>("/api/apps", { method: "POST", body: JSON.stringify(data) }),

--- a/web/src/pages/app-detail.tsx
+++ b/web/src/pages/app-detail.tsx
@@ -888,6 +888,7 @@ function ToolsEditor({ app, onUpdate }: { app: any; onUpdate: () => void }) {
   const [importing, setImporting] = useState(false);
   const [showMcpImport, setShowMcpImport] = useState(false);
   const { toast } = useToast();
+  const { confirm, ConfirmDialog } = useConfirm();
 
   function addTool() {
     setTools([...tools, { name: "", description: "", command: "", parameters: "" }]);
@@ -915,6 +916,14 @@ function ToolsEditor({ app, onUpdate }: { app: any; onUpdate: () => void }) {
       if (result.tools.length === 0) {
         toast({ variant: "destructive", title: "未发现工具", description: "MCP 服务器未返回任何工具定义" });
       } else {
+        if (tools.length > 0) {
+          const ok = await confirm({
+            title: "替换现有工具",
+            description: `将从 MCP 服务器导入 ${result.tools.length} 个工具，替换当前全部 ${tools.length} 个工具。确定继续？`,
+            confirmText: "替换",
+          });
+          if (!ok) { setImporting(false); return; }
+        }
         const imported = result.tools.map((t) => ({
           name: t.name,
           description: t.description || "",
@@ -926,7 +935,9 @@ function ToolsEditor({ app, onUpdate }: { app: any; onUpdate: () => void }) {
         const serverInfo = result.server_name
           ? `${result.server_name}${result.server_version ? ` v${result.server_version}` : ""}`
           : "MCP 服务器";
-        toast({ title: `已导入 ${result.tools.length} 个工具`, description: `来自 ${serverInfo}` });
+        let desc = `来自 ${serverInfo}`;
+        if (result.truncated) desc += "（工具数量超限，已截断）";
+        toast({ title: `已导入 ${result.tools.length} 个工具`, description: desc });
       }
     } catch (e: any) {
       toast({ variant: "destructive", title: "导入失败", description: e.message });
@@ -951,6 +962,7 @@ function ToolsEditor({ app, onUpdate }: { app: any; onUpdate: () => void }) {
 
   return (
     <div className="space-y-6">
+      {ConfirmDialog}
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-base font-semibold">命令 / 工具</h2>
@@ -987,13 +999,15 @@ function ToolsEditor({ app, onUpdate }: { app: any; onUpdate: () => void }) {
               value={mcpUrl}
               onChange={(e) => setMcpUrl(e.target.value)}
               className="h-8 text-xs font-mono"
+              aria-label="MCP 服务器地址"
             />
             <textarea
-              placeholder={"自定义请求头（可选，每行一个，格式 Key: Value）\n如 Authorization: Bearer token123"}
+              placeholder="自定义请求头（可选，每行一个，格式 Key: Value）"
               value={mcpHeaders}
               onChange={(e) => setMcpHeaders(e.target.value)}
               rows={2}
               className="w-full rounded-md border border-input bg-transparent px-2 py-1 text-xs font-mono placeholder:text-muted-foreground/40 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 resize-none"
+              aria-label="自定义请求头"
             />
             <div className="flex gap-2">
               <Button

--- a/web/src/pages/app-detail.tsx
+++ b/web/src/pages/app-detail.tsx
@@ -883,6 +883,11 @@ function ToolsEditor({ app, onUpdate }: { app: any; onUpdate: () => void }) {
     })),
   );
   const [saving, setSaving] = useState(false);
+  const [mcpUrl, setMcpUrl] = useState("");
+  const [mcpHeaders, setMcpHeaders] = useState("");
+  const [importing, setImporting] = useState(false);
+  const [showMcpImport, setShowMcpImport] = useState(false);
+  const { toast } = useToast();
 
   function addTool() {
     setTools([...tools, { name: "", description: "", command: "", parameters: "" }]);
@@ -892,6 +897,41 @@ function ToolsEditor({ app, onUpdate }: { app: any; onUpdate: () => void }) {
   }
   function updateTool(index: number, field: string, value: string) {
     setTools(tools.map((t, i) => (i === index ? { ...t, [field]: value } : t)));
+  }
+
+  async function handleImportMCP() {
+    if (!mcpUrl.trim()) return;
+    setImporting(true);
+    try {
+      let headers: Record<string, string> | undefined;
+      if (mcpHeaders.trim()) {
+        headers = {};
+        for (const line of mcpHeaders.split("\n")) {
+          const idx = line.indexOf(":");
+          if (idx > 0) headers[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+        }
+      }
+      const result = await api.importMCP({ url: mcpUrl.trim(), headers });
+      if (result.tools.length === 0) {
+        toast({ variant: "destructive", title: "未发现工具", description: "MCP 服务器未返回任何工具定义" });
+      } else {
+        const imported = result.tools.map((t) => ({
+          name: t.name,
+          description: t.description || "",
+          command: "",
+          parameters: t.parameters ? JSON.stringify(t.parameters, null, 2) : "",
+        }));
+        setTools(imported);
+        setShowMcpImport(false);
+        const serverInfo = result.server_name
+          ? `${result.server_name}${result.server_version ? ` v${result.server_version}` : ""}`
+          : "MCP 服务器";
+        toast({ title: `已导入 ${result.tools.length} 个工具`, description: `来自 ${serverInfo}` });
+      }
+    } catch (e: any) {
+      toast({ variant: "destructive", title: "导入失败", description: e.message });
+    }
+    setImporting(false);
   }
 
   async function handleSave() {
@@ -918,10 +958,65 @@ function ToolsEditor({ app, onUpdate }: { app: any; onUpdate: () => void }) {
             定义应用的工具和命令，用户通过 /command 触发。
           </p>
         </div>
-        <Button variant="outline" size="sm" className="h-7 text-xs" onClick={addTool}>
-          <Plus className="w-3 h-3 mr-1" /> 添加
-        </Button>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => setShowMcpImport(!showMcpImport)}
+          >
+            <Download className="w-3 h-3 mr-1" /> 从 MCP 导入
+          </Button>
+          <Button variant="outline" size="sm" className="h-7 text-xs" onClick={addTool}>
+            <Plus className="w-3 h-3 mr-1" /> 添加
+          </Button>
+        </div>
       </div>
+
+      {showMcpImport && (
+        <Card>
+          <CardHeader>
+            <CardTitle>从 MCP 服务器导入</CardTitle>
+            <CardDescription>
+              输入 MCP 服务器的 Streamable HTTP 地址，自动发现并导入工具定义。导入会替换当前所有工具。
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Input
+              placeholder="https://your-mcp-server.example.com/mcp"
+              value={mcpUrl}
+              onChange={(e) => setMcpUrl(e.target.value)}
+              className="h-8 text-xs font-mono"
+            />
+            <textarea
+              placeholder={"自定义请求头（可选，每行一个，格式 Key: Value）\n如 Authorization: Bearer token123"}
+              value={mcpHeaders}
+              onChange={(e) => setMcpHeaders(e.target.value)}
+              rows={2}
+              className="w-full rounded-md border border-input bg-transparent px-2 py-1 text-xs font-mono placeholder:text-muted-foreground/40 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 resize-none"
+            />
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                onClick={handleImportMCP}
+                disabled={importing || !mcpUrl.trim()}
+                className="h-7 text-xs"
+              >
+                {importing && <Loader2 className="h-3 w-3 animate-spin mr-1" />}
+                {importing ? "正在发现..." : "发现工具"}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowMcpImport(false)}
+                className="h-7 text-xs"
+              >
+                取消
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {tools.length === 0 ? (
         <p className="text-xs text-muted-foreground">暂无工具。点击右上角添加。</p>


### PR DESCRIPTION
## Summary
- 新增 `POST /api/apps/import-mcp` 后端接口，通过 mcp-go 客户端连接远程 MCP 服务器，调用 `tools/list` 发现工具定义并转换为 App 工具格式返回
- 在应用详情页「命令/工具」编辑区新增「从 MCP 导入」按钮，支持输入 MCP 服务器地址和可选的自定义请求头（如 Authorization），一键导入工具定义
- 导入后自动填充工具名称、描述和参数 JSON Schema，无需手动逐个填写

## Test plan
- [ ] 输入一个有效的 MCP 服务器 URL，点击「发现工具」，确认工具被正确导入
- [ ] 输入需要认证的 MCP 服务器 URL，填写 `Authorization: Bearer <token>` 请求头，确认导入成功
- [ ] 输入无效 URL，确认显示错误提示
- [ ] 输入无工具的 MCP 服务器，确认提示「未发现工具」
- [ ] 导入后点击「保存工具」，确认工具被持久化
- [ ] 确认导入会替换当前所有工具而非追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import tool definitions from remote MCP servers by URL, returning server name/version and a tools list (with truncation indicator).
  * Optionally provide request headers for import.

* **UX Improvements**
  * New import panel in the Tools editor with progress states, loader, confirmations, and success/destructive toasts.
  * Import button disabled while importing or when URL is empty.

* **Validation & Safety**
  * Enforces URL, request size and timeout limits and filters unsafe headers during import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->