### PR TITLE
fix: robust MCP import with SSE fallback and staged errors

### DIFF
--- a/internal/api/mcp_import.go
+++ b/internal/api/mcp_import.go
@@ -170,14 +170,41 @@ func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers
 		Timeout: 15 * time.Second,
 	}
 
-	opts := []transport.StreamableHTTPCOption{
-		transport.WithHTTPBasicClient(httpClient),
+	// Try Streamable HTTP first (new spec). If the server signals it is a legacy
+	// SSE server, fall back to the SSE transport.
+	result, err = runDiscovery(ctx, hubVersion, serverURL, headers, httpClient, transportStreamable)
+	if err != nil && isLegacySSESignal(err) {
+		slog.Info("mcp import: retrying with SSE transport", "url", serverURL)
+		result, err = runDiscovery(ctx, hubVersion, serverURL, headers, httpClient, transportSSE)
 	}
-	if len(headers) > 0 {
-		opts = append(opts, transport.WithHTTPHeaders(headers))
-	}
+	return result, err
+}
 
-	c, cerr := client.NewStreamableHttpClient(serverURL, opts...)
+type transportKind int
+
+const (
+	transportStreamable transportKind = iota
+	transportSSE
+)
+
+func runDiscovery(ctx context.Context, hubVersion, serverURL string, headers map[string]string, httpClient *http.Client, kind transportKind) (*mcpImportResult, error) {
+	var c *client.Client
+	var cerr error
+
+	switch kind {
+	case transportSSE:
+		opts := []transport.ClientOption{transport.WithHTTPClient(httpClient)}
+		if len(headers) > 0 {
+			opts = append(opts, transport.WithHeaders(headers))
+		}
+		c, cerr = client.NewSSEMCPClient(serverURL, opts...)
+	default:
+		opts := []transport.StreamableHTTPCOption{transport.WithHTTPBasicClient(httpClient)}
+		if len(headers) > 0 {
+			opts = append(opts, transport.WithHTTPHeaders(headers))
+		}
+		c, cerr = client.NewStreamableHttpClient(serverURL, opts...)
+	}
 	if cerr != nil {
 		return nil, &importError{Stage: "connect", Detail: "invalid MCP client configuration", Err: cerr}
 	}
@@ -205,9 +232,7 @@ func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers
 		return nil, wrapTransportError("initialize", ierr)
 	}
 
-	result = &mcpImportResult{
-		Tools: []store.AppTool{},
-	}
+	result := &mcpImportResult{Tools: []store.AppTool{}}
 	if initResult != nil {
 		result.ServerName = initResult.ServerInfo.Name
 		result.ServerVersion = initResult.ServerInfo.Version
@@ -240,6 +265,16 @@ func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers
 	return result, nil
 }
 
+// isLegacySSESignal reports whether the error indicates the server speaks the
+// legacy SSE transport instead of Streamable HTTP, so discovery should retry.
+func isLegacySSESignal(err error) bool {
+	if err == nil {
+		return false
+	}
+	low := strings.ToLower(err.Error())
+	return strings.Contains(low, "legacy sse")
+}
+
 // wrapTransportError classifies a network/protocol error into an importError
 // with a concise, user-safe message.
 func wrapTransportError(stage string, err error) error {
@@ -265,6 +300,8 @@ func wrapTransportError(stage string, err error) error {
 		return &importError{Stage: stage, Detail: "MCP endpoint not found (404) — check the URL path", Err: err}
 	case strings.Contains(low, "method not allowed") || strings.Contains(low, "405"):
 		return &importError{Stage: stage, Detail: "MCP server does not accept Streamable HTTP transport", Err: err}
+	case strings.Contains(low, "legacy sse"):
+		return &importError{Stage: stage, Detail: "MCP server uses the legacy SSE transport and the fallback also failed", Err: err}
 	default:
 		return &importError{Stage: stage, Detail: truncate(msg, 200), Err: err}
 	}

--- a/internal/api/mcp_import.go
+++ b/internal/api/mcp_import.go
@@ -23,9 +23,25 @@ import (
 // first try cannot starve the SSE fallback of the parent context budget.
 const perAttemptTimeout = 10 * time.Second
 
-// httpStatusRE matches an HTTP status word-bounded in an error message, so
-// status like "401" in a URL fragment or port won't cause a false match.
-var httpStatusRE = regexp.MustCompile(`\b(40[1345])\b`)
+// minFallbackBudget is the minimum parent-context time remaining required to
+// retry discovery over SSE after a Streamable HTTP timeout.
+const minFallbackBudget = 3 * time.Second
+
+// httpStatusRE matches a 4xx status we care about inside an error message.
+// The leading `[^\d/:a-zA-Z]` (or start-of-string) rejects digits that are
+// really part of a URL path segment (e.g. "/mcp/405") or TCP port
+// (e.g. ":405"), which would otherwise false-match with plain `\b`.
+var httpStatusRE = regexp.MustCompile(`(?:^|[^\d/:a-zA-Z])(40[13456])\b`)
+
+// findHTTPStatus extracts a matched 4xx status code from err's message, or
+// empty string if none is present.
+func findHTTPStatus(msg string) string {
+	m := httpStatusRE.FindStringSubmatch(msg)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
 
 const maxImportTools = 200
 
@@ -138,6 +154,9 @@ func truncate(s string, n int) string {
 	for n > 0 && !utf8.RuneStart(s[n]) {
 		n--
 	}
+	if n == 0 {
+		return "..."
+	}
 	return s[:n] + "..."
 }
 
@@ -186,18 +205,38 @@ func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers
 	}
 
 	// Try Streamable HTTP first (new spec). If the server signals it is a legacy
-	// SSE server, fall back to the SSE transport. Each attempt gets its own
-	// bounded context so the retry is not starved of budget.
+	// SSE server — or the first attempt merely timed out while the parent ctx
+	// still has usable budget — fall back to the SSE transport. Each attempt
+	// gets its own bounded context so the retry is not starved of budget.
 	firstCtx, firstCancel := context.WithTimeout(ctx, perAttemptTimeout)
 	result, err = runDiscovery(firstCtx, hubVersion, serverURL, headers, httpClient, transportStreamable)
 	firstCancel()
-	if err != nil && isLegacySSESignal(err) {
+	if err != nil && shouldFallbackToSSE(ctx, err) {
 		slog.Info("mcp import: retrying with SSE transport", "url", serverURL)
 		retryCtx, retryCancel := context.WithTimeout(ctx, perAttemptTimeout)
 		result, err = runDiscovery(retryCtx, hubVersion, serverURL, headers, httpClient, transportSSE)
 		retryCancel()
 	}
 	return result, err
+}
+
+// shouldFallbackToSSE decides whether a failed Streamable HTTP attempt should
+// be retried over SSE. Retries on explicit legacy signals or on a first-attempt
+// timeout when the parent context still has at least minFallbackBudget left —
+// a single slow response should not foreclose the fallback for a server that
+// happens to be slow but legacy.
+func shouldFallbackToSSE(parent context.Context, err error) bool {
+	if isLegacySSESignal(err) {
+		return true
+	}
+	var ie *importError
+	if errors.As(err, &ie) && ie.Stage == "timeout" {
+		if dl, ok := parent.Deadline(); ok {
+			return time.Until(dl) >= minFallbackBudget
+		}
+		return true
+	}
+	return false
 }
 
 type transportKind int
@@ -298,7 +337,7 @@ func isLegacySSESignal(err error) bool {
 	if strings.Contains(low, "legacy sse") {
 		return true
 	}
-	if m := httpStatusRE.FindString(low); m == "405" || m == "406" {
+	if m := findHTTPStatus(low); m == "405" || m == "406" {
 		return true
 	}
 	return false
@@ -327,14 +366,14 @@ func wrapTransportError(stage string, err error) error {
 		return &importError{Stage: stage, Detail: "MCP server does not accept Streamable HTTP transport", Err: err}
 	}
 
-	switch httpStatusRE.FindString(low) {
+	switch findHTTPStatus(low) {
 	case "401":
 		return &importError{Stage: stage, Detail: "MCP server rejected credentials (401)", Err: err}
 	case "403":
 		return &importError{Stage: stage, Detail: "MCP server forbade access (403)", Err: err}
 	case "404":
 		return &importError{Stage: stage, Detail: "MCP endpoint not found (404) — check the URL path", Err: err}
-	case "405":
+	case "405", "406":
 		return &importError{Stage: stage, Detail: "MCP server does not accept Streamable HTTP transport", Err: err}
 	}
 

--- a/internal/api/mcp_import.go
+++ b/internal/api/mcp_import.go
@@ -19,8 +19,9 @@ import (
 	"github.com/openilink/openilink-hub/internal/store"
 )
 
-// perAttemptTimeout caps each discovery attempt so a slow Streamable HTTP
-// first try cannot starve the SSE fallback of the parent context budget.
+// perAttemptTimeout caps the SSE fallback attempt so a stuck retry cannot
+// exceed the handler's parent-context deadline. The initial Streamable HTTP
+// attempt is not capped and uses the full parent budget.
 const perAttemptTimeout = 10 * time.Second
 
 // minFallbackBudget is the minimum parent-context time remaining required to
@@ -204,13 +205,12 @@ func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers
 		Timeout: 15 * time.Second,
 	}
 
-	// Try Streamable HTTP first (new spec). If the server signals it is a legacy
-	// SSE server — or the first attempt merely timed out while the parent ctx
-	// still has usable budget — fall back to the SSE transport. Each attempt
-	// gets its own bounded context so the retry is not starved of budget.
-	firstCtx, firstCancel := context.WithTimeout(ctx, perAttemptTimeout)
-	result, err = runDiscovery(firstCtx, hubVersion, serverURL, headers, httpClient, transportStreamable)
-	firstCancel()
+	// Try Streamable HTTP first (new spec) with the full parent-context budget
+	// so slow-but-healthy Streamable servers are not regressed. If the server
+	// signals it is a legacy SSE server — or the first attempt timed out while
+	// the parent context still has usable budget — fall back to SSE with a
+	// bounded retry so a stuck retry cannot exceed the handler deadline.
+	result, err = runDiscovery(ctx, hubVersion, serverURL, headers, httpClient, transportStreamable)
 	if err != nil && shouldFallbackToSSE(ctx, err) {
 		slog.Info("mcp import: retrying with SSE transport", "url", serverURL)
 		retryCtx, retryCancel := context.WithTimeout(ctx, perAttemptTimeout)

--- a/internal/api/mcp_import.go
+++ b/internal/api/mcp_import.go
@@ -8,14 +8,24 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/openilink/openilink-hub/internal/store"
 )
+
+// perAttemptTimeout caps each discovery attempt so a slow Streamable HTTP
+// first try cannot starve the SSE fallback of the parent context budget.
+const perAttemptTimeout = 10 * time.Second
+
+// httpStatusRE matches an HTTP status word-bounded in an error message, so
+// status like "401" in a URL fragment or port won't cause a false match.
+var httpStatusRE = regexp.MustCompile(`\b(40[1345])\b`)
 
 const maxImportTools = 200
 
@@ -114,14 +124,19 @@ func classifyImportError(ctx context.Context, err error) (int, string, string) {
 	}
 
 	if ctx.Err() == context.DeadlineExceeded || errors.Is(err, context.DeadlineExceeded) {
-		return http.StatusGatewayTimeout, "MCP server did not respond within 15s", "timeout"
+		return http.StatusGatewayTimeout, "MCP server did not respond in time", "timeout"
 	}
 	return http.StatusBadGateway, truncate(err.Error(), 200), "unknown"
 }
 
+// truncate trims s to at most n bytes without splitting a multibyte rune and
+// appends an ellipsis. Used on error strings that surface in JSON responses.
 func truncate(s string, n int) string {
 	if len(s) <= n {
 		return s
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
 	}
 	return s[:n] + "..."
 }
@@ -171,11 +186,16 @@ func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers
 	}
 
 	// Try Streamable HTTP first (new spec). If the server signals it is a legacy
-	// SSE server, fall back to the SSE transport.
-	result, err = runDiscovery(ctx, hubVersion, serverURL, headers, httpClient, transportStreamable)
+	// SSE server, fall back to the SSE transport. Each attempt gets its own
+	// bounded context so the retry is not starved of budget.
+	firstCtx, firstCancel := context.WithTimeout(ctx, perAttemptTimeout)
+	result, err = runDiscovery(firstCtx, hubVersion, serverURL, headers, httpClient, transportStreamable)
+	firstCancel()
 	if err != nil && isLegacySSESignal(err) {
 		slog.Info("mcp import: retrying with SSE transport", "url", serverURL)
-		result, err = runDiscovery(ctx, hubVersion, serverURL, headers, httpClient, transportSSE)
+		retryCtx, retryCancel := context.WithTimeout(ctx, perAttemptTimeout)
+		result, err = runDiscovery(retryCtx, hubVersion, serverURL, headers, httpClient, transportSSE)
+		retryCancel()
 	}
 	return result, err
 }
@@ -267,12 +287,21 @@ func runDiscovery(ctx context.Context, hubVersion, serverURL string, headers map
 
 // isLegacySSESignal reports whether the error indicates the server speaks the
 // legacy SSE transport instead of Streamable HTTP, so discovery should retry.
+// Triggers on either mcp-go's explicit "legacy sse" hint, or an HTTP 405/406
+// from the Streamable HTTP initialize POST, which the spec flags as the
+// signal to fall back.
 func isLegacySSESignal(err error) bool {
 	if err == nil {
 		return false
 	}
 	low := strings.ToLower(err.Error())
-	return strings.Contains(low, "legacy sse")
+	if strings.Contains(low, "legacy sse") {
+		return true
+	}
+	if m := httpStatusRE.FindString(low); m == "405" || m == "406" {
+		return true
+	}
+	return false
 }
 
 // wrapTransportError classifies a network/protocol error into an importError
@@ -283,7 +312,7 @@ func wrapTransportError(stage string, err error) error {
 
 	switch {
 	case errors.Is(err, context.DeadlineExceeded) || strings.Contains(low, "deadline exceeded"):
-		return &importError{Stage: "timeout", Detail: "MCP server did not respond within 15s", Err: err}
+		return &importError{Stage: "timeout", Detail: "MCP server did not respond in time", Err: err}
 	case strings.Contains(low, "private/internal"):
 		return &importError{Stage: "blocked", Detail: "MCP server resolves to a private/internal IP and was blocked", Err: err}
 	case strings.Contains(low, "cannot resolve host"):
@@ -292,18 +321,29 @@ func wrapTransportError(stage string, err error) error {
 		return &importError{Stage: stage, Detail: "connection refused by MCP server", Err: err}
 	case strings.Contains(low, "tls") || strings.Contains(low, "x509"):
 		return &importError{Stage: stage, Detail: "TLS handshake failed", Err: err}
-	case strings.Contains(low, "401") || strings.Contains(low, "unauthorized"):
-		return &importError{Stage: stage, Detail: "MCP server rejected credentials (401)", Err: err}
-	case strings.Contains(low, "403") || strings.Contains(low, "forbidden"):
-		return &importError{Stage: stage, Detail: "MCP server forbade access (403)", Err: err}
-	case strings.Contains(low, "404"):
-		return &importError{Stage: stage, Detail: "MCP endpoint not found (404) — check the URL path", Err: err}
-	case strings.Contains(low, "method not allowed") || strings.Contains(low, "405"):
-		return &importError{Stage: stage, Detail: "MCP server does not accept Streamable HTTP transport", Err: err}
 	case strings.Contains(low, "legacy sse"):
 		return &importError{Stage: stage, Detail: "MCP server uses the legacy SSE transport and the fallback also failed", Err: err}
-	default:
-		return &importError{Stage: stage, Detail: truncate(msg, 200), Err: err}
+	case strings.Contains(low, "method not allowed"):
+		return &importError{Stage: stage, Detail: "MCP server does not accept Streamable HTTP transport", Err: err}
 	}
+
+	switch httpStatusRE.FindString(low) {
+	case "401":
+		return &importError{Stage: stage, Detail: "MCP server rejected credentials (401)", Err: err}
+	case "403":
+		return &importError{Stage: stage, Detail: "MCP server forbade access (403)", Err: err}
+	case "404":
+		return &importError{Stage: stage, Detail: "MCP endpoint not found (404) — check the URL path", Err: err}
+	case "405":
+		return &importError{Stage: stage, Detail: "MCP server does not accept Streamable HTTP transport", Err: err}
+	}
+
+	if strings.Contains(low, "unauthorized") {
+		return &importError{Stage: stage, Detail: "MCP server rejected credentials (401)", Err: err}
+	}
+	if strings.Contains(low, "forbidden") {
+		return &importError{Stage: stage, Detail: "MCP server forbade access (403)", Err: err}
+	}
+	return &importError{Stage: stage, Detail: truncate(msg, 200), Err: err}
 }
 

--- a/internal/api/mcp_import.go
+++ b/internal/api/mcp_import.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -214,8 +215,8 @@ func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers
 	if err != nil && shouldFallbackToSSE(ctx, err) {
 		slog.Info("mcp import: retrying with SSE transport", "url", serverURL)
 		retryCtx, retryCancel := context.WithTimeout(ctx, perAttemptTimeout)
+		defer retryCancel()
 		result, err = runDiscovery(retryCtx, hubVersion, serverURL, headers, httpClient, transportSSE)
-		retryCancel()
 	}
 	return result, err
 }
@@ -301,6 +302,9 @@ func runDiscovery(ctx context.Context, hubVersion, serverURL string, headers map
 	if lerr != nil {
 		return nil, wrapTransportError("list_tools", lerr)
 	}
+	if toolsResult == nil {
+		return result, nil
+	}
 
 	for i, t := range toolsResult.Tools {
 		if i >= maxImportTools {
@@ -326,21 +330,42 @@ func runDiscovery(ctx context.Context, hubVersion, serverURL string, headers map
 
 // isLegacySSESignal reports whether the error indicates the server speaks the
 // legacy SSE transport instead of Streamable HTTP, so discovery should retry.
-// Triggers on either mcp-go's explicit "legacy sse" hint, or an HTTP 405/406
-// from the Streamable HTTP initialize POST, which the spec flags as the
-// signal to fall back.
+// Triggers on mcp-go's explicit "legacy sse" hint, an HTTP 405/406 from the
+// Streamable HTTP initialize POST (per MCP spec), or the equivalent textual
+// phrases when no numeric status is surfaced in the wrapped error.
 func isLegacySSESignal(err error) bool {
 	if err == nil {
 		return false
 	}
 	low := strings.ToLower(err.Error())
-	if strings.Contains(low, "legacy sse") {
+	if strings.Contains(low, "legacy sse") ||
+		strings.Contains(low, "method not allowed") ||
+		strings.Contains(low, "not acceptable") {
 		return true
 	}
 	if m := findHTTPStatus(low); m == "405" || m == "406" {
 		return true
 	}
 	return false
+}
+
+// isTimeoutErr classifies an error as a transport-level timeout, covering
+// context deadlines, net.Error(Timeout), and Go's ResponseHeaderTimeout
+// message which does not wrap context.DeadlineExceeded.
+func isTimeoutErr(err error, lowerMsg string) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	return strings.Contains(lowerMsg, "deadline exceeded") ||
+		strings.Contains(lowerMsg, "timeout awaiting response headers") ||
+		strings.Contains(lowerMsg, "i/o timeout")
 }
 
 // wrapTransportError classifies a network/protocol error into an importError
@@ -350,7 +375,7 @@ func wrapTransportError(stage string, err error) error {
 	low := strings.ToLower(msg)
 
 	switch {
-	case errors.Is(err, context.DeadlineExceeded) || strings.Contains(low, "deadline exceeded"):
+	case isTimeoutErr(err, low):
 		return &importError{Stage: "timeout", Detail: "MCP server did not respond in time", Err: err}
 	case strings.Contains(low, "private/internal"):
 		return &importError{Stage: "blocked", Detail: "MCP server resolves to a private/internal IP and was blocked", Err: err}

--- a/internal/api/mcp_import.go
+++ b/internal/api/mcp_import.go
@@ -3,10 +3,12 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/mark3labs/mcp-go/client"
@@ -37,6 +39,23 @@ type mcpImportResult struct {
 	Truncated     bool            `json:"truncated,omitempty"`
 }
 
+// importError carries stage + user-facing detail so the frontend can show a
+// meaningful message instead of a generic "bad gateway".
+type importError struct {
+	Stage  string // connect | initialize | list_tools | blocked | timeout | panic
+	Detail string
+	Err    error
+}
+
+func (e *importError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %s: %v", e.Stage, e.Detail, e.Err)
+	}
+	return fmt.Sprintf("%s: %s", e.Stage, e.Detail)
+}
+
+func (e *importError) Unwrap() error { return e.Err }
+
 // handleImportMCP discovers tools from a remote MCP server.
 func (s *Server) handleImportMCP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
@@ -65,8 +84,9 @@ func (s *Server) handleImportMCP(w http.ResponseWriter, r *http.Request) {
 
 	result, err := discoverMCPTools(ctx, s.Version, req.URL, headers)
 	if err != nil {
-		slog.Warn("mcp import failed", "url", req.URL, "err", err)
-		jsonError(w, "failed to connect to MCP server", http.StatusBadGateway)
+		status, msg, stage := classifyImportError(ctx, err)
+		slog.Warn("mcp import failed", "url", req.URL, "stage", stage, "status", status, "err", err, "duration_ms", time.Since(start).Milliseconds())
+		jsonError(w, msg, status)
 		return
 	}
 
@@ -74,6 +94,36 @@ func (s *Server) handleImportMCP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(result)
+}
+
+// classifyImportError maps a discovery failure to an HTTP status and a
+// user-facing message. Returns (status, message, stage-for-logs).
+func classifyImportError(ctx context.Context, err error) (int, string, string) {
+	var ie *importError
+	if errors.As(err, &ie) {
+		switch ie.Stage {
+		case "blocked":
+			return http.StatusBadRequest, ie.Detail, ie.Stage
+		case "timeout":
+			return http.StatusGatewayTimeout, ie.Detail, ie.Stage
+		case "panic":
+			return http.StatusInternalServerError, "MCP client crashed while contacting the server", ie.Stage
+		default:
+			return http.StatusBadGateway, fmt.Sprintf("%s failed: %s", ie.Stage, ie.Detail), ie.Stage
+		}
+	}
+
+	if ctx.Err() == context.DeadlineExceeded || errors.Is(err, context.DeadlineExceeded) {
+		return http.StatusGatewayTimeout, "MCP server did not respond within 15s", "timeout"
+	}
+	return http.StatusBadGateway, truncate(err.Error(), 200), "unknown"
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
 }
 
 func filterHeaders(headers map[string]string) map[string]string {
@@ -105,10 +155,16 @@ func stringToLower(s string) string {
 	return string(b)
 }
 
-func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers map[string]string) (*mcpImportResult, error) {
+func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers map[string]string) (result *mcpImportResult, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = &importError{Stage: "panic", Detail: fmt.Sprintf("%v", r)}
+		}
+	}()
+
 	httpClient := &http.Client{
 		Transport: &http.Transport{
-			DialContext: ssrfSafeDialContext,
+			DialContext:           ssrfSafeDialContext,
 			ResponseHeaderTimeout: 10 * time.Second,
 		},
 		Timeout: 15 * time.Second,
@@ -121,14 +177,14 @@ func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers
 		opts = append(opts, transport.WithHTTPHeaders(headers))
 	}
 
-	c, err := client.NewStreamableHttpClient(serverURL, opts...)
-	if err != nil {
-		return nil, err
+	c, cerr := client.NewStreamableHttpClient(serverURL, opts...)
+	if cerr != nil {
+		return nil, &importError{Stage: "connect", Detail: "invalid MCP client configuration", Err: cerr}
 	}
 	defer c.Close()
 
-	if err := c.Start(ctx); err != nil {
-		return nil, err
+	if serr := c.Start(ctx); serr != nil {
+		return nil, wrapTransportError("connect", serr)
 	}
 
 	version := hubVersion
@@ -136,7 +192,7 @@ func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers
 		version = "dev"
 	}
 
-	initResult, err := c.Initialize(ctx, mcp.InitializeRequest{
+	initResult, ierr := c.Initialize(ctx, mcp.InitializeRequest{
 		Params: mcp.InitializeParams{
 			ClientInfo: mcp.Implementation{
 				Name:    "OpeniLink Hub",
@@ -145,11 +201,11 @@ func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers
 			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
 		},
 	})
-	if err != nil {
-		return nil, err
+	if ierr != nil {
+		return nil, wrapTransportError("initialize", ierr)
 	}
 
-	result := &mcpImportResult{
+	result = &mcpImportResult{
 		Tools: []store.AppTool{},
 	}
 	if initResult != nil {
@@ -157,9 +213,9 @@ func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers
 		result.ServerVersion = initResult.ServerInfo.Version
 	}
 
-	toolsResult, err := c.ListTools(ctx, mcp.ListToolsRequest{})
-	if err != nil {
-		return nil, fmt.Errorf("list tools: %w", err)
+	toolsResult, lerr := c.ListTools(ctx, mcp.ListToolsRequest{})
+	if lerr != nil {
+		return nil, wrapTransportError("list_tools", lerr)
 	}
 
 	for i, t := range toolsResult.Tools {
@@ -182,5 +238,35 @@ func discoverMCPTools(ctx context.Context, hubVersion, serverURL string, headers
 	}
 
 	return result, nil
+}
+
+// wrapTransportError classifies a network/protocol error into an importError
+// with a concise, user-safe message.
+func wrapTransportError(stage string, err error) error {
+	msg := err.Error()
+	low := strings.ToLower(msg)
+
+	switch {
+	case errors.Is(err, context.DeadlineExceeded) || strings.Contains(low, "deadline exceeded"):
+		return &importError{Stage: "timeout", Detail: "MCP server did not respond within 15s", Err: err}
+	case strings.Contains(low, "private/internal"):
+		return &importError{Stage: "blocked", Detail: "MCP server resolves to a private/internal IP and was blocked", Err: err}
+	case strings.Contains(low, "cannot resolve host"):
+		return &importError{Stage: stage, Detail: "cannot resolve MCP server hostname", Err: err}
+	case strings.Contains(low, "connection refused"):
+		return &importError{Stage: stage, Detail: "connection refused by MCP server", Err: err}
+	case strings.Contains(low, "tls") || strings.Contains(low, "x509"):
+		return &importError{Stage: stage, Detail: "TLS handshake failed", Err: err}
+	case strings.Contains(low, "401") || strings.Contains(low, "unauthorized"):
+		return &importError{Stage: stage, Detail: "MCP server rejected credentials (401)", Err: err}
+	case strings.Contains(low, "403") || strings.Contains(low, "forbidden"):
+		return &importError{Stage: stage, Detail: "MCP server forbade access (403)", Err: err}
+	case strings.Contains(low, "404"):
+		return &importError{Stage: stage, Detail: "MCP endpoint not found (404) — check the URL path", Err: err}
+	case strings.Contains(low, "method not allowed") || strings.Contains(low, "405"):
+		return &importError{Stage: stage, Detail: "MCP server does not accept Streamable HTTP transport", Err: err}
+	default:
+		return &importError{Stage: stage, Detail: truncate(msg, 200), Err: err}
+	}
 }
 


### PR DESCRIPTION
## Summary
- Add panic recovery in MCP discovery so mcp-go library crashes don't take down the pod
- Classify failures into stages (connect / initialize / list_tools / blocked / timeout / panic) and return specific HTTP status + message instead of a blanket 502
- Fall back to legacy SSE transport when the server returns 4xx for the Streamable HTTP initialize (fixes imports from servers like `openilink-pet.cinwell.workers.dev/tools`)

## Why
A user-reported 502 on `/api/apps/import-mcp` traced back to the MCP server only supporting the legacy SSE transport. The hub returned a generic `StatusBadGateway` with no detail, and Cloudflare replaced the tiny JSON body with its own error page. Now discovery retries with SSE automatically, and any remaining failure surfaces a concrete reason to the frontend.

## Test plan
- [x] Builds clean (`go build ./internal/api/...`)
- [x] Deployed to cognet-hk k3s cluster, pod healthy, bots started
- [ ] Retry the previously failing MCP import from the UI and confirm success
- [ ] Trigger a bogus URL / auth failure and confirm the error message is specific (not generic 502)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More specific error messages and HTTP status mapping for import failures.
  * Added crash protection during tool discovery to prevent unhandled panics.
  * Added transport fallback and retry between protocols to improve import reliability.
  * Introduced per-attempt timeouts to avoid stalled discovery attempts.
  * Enhanced warning logs to include stage, status, and duration for clearer diagnostics.
  * Improved classification and safe truncation of error details; detects legacy endpoints to trigger fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->