### PR TITLE
fix: route app/tools updates to installation tools for marketplace apps (#246)

### DIFF
--- a/docs/app-development.md
+++ b/docs/app-development.md
@@ -471,7 +471,7 @@ For **marketplace / builtin** apps the AppDef is immutable, so this call is tran
 
 Response:
 ```json
-{"ok": true, "tool_count": 5}
+{"ok": true, "tool_count": 5, "scope": "app"}
 ```
 
 ### Update Installation Tools

--- a/docs/app-development.md
+++ b/docs/app-development.md
@@ -461,7 +461,9 @@ PUT /bot/v1/app/tools
 Authorization: Bearer {app_token}
 ```
 
-Dynamically update the **app-level** tools/commands at runtime. Requires `tools:write` scope. Only works for local apps (not marketplace or builtin). App-level tools are shared across all installations of the app.
+Dynamically update the **app-level** tools/commands at runtime. Requires `tools:write` scope. App-level tools are shared across all installations of the app.
+
+For **marketplace / builtin** apps the AppDef is immutable, so this call is transparently routed to the per-installation tools instead (see `PUT /bot/v1/installation/tools`). The response will include `"scope": "installation"` in that case; for local apps it returns `"scope": "app"`. This means existing app clients can keep using this endpoint regardless of whether they are installed from the marketplace.
 
 | Field | Required | Description |
 |---|---|---|

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1502,7 +1502,7 @@ func TestBotAPI_UpdateTools(t *testing.T) {
 		}
 	})
 
-	t.Run("update tools fails for marketplace app", func(t *testing.T) {
+	t.Run("update tools on marketplace app falls back to installation tools", func(t *testing.T) {
 		// Create marketplace app (has registry set)
 		mktScopes, _ := json.Marshal([]string{"tools:write"})
 		mktApp, err := env.store.CreateApp(&store.App{
@@ -1522,12 +1522,41 @@ func TestBotAPI_UpdateTools(t *testing.T) {
 			withBearer(mktInst.AppToken))
 		defer resp.Body.Close()
 
-		if resp.StatusCode != 403 {
-			t.Fatalf("expected 403, got %d", resp.StatusCode)
+		if resp.StatusCode != 200 {
+			body := decodeJSON(t, resp)
+			t.Fatalf("expected 200, got %d: %v", resp.StatusCode, body)
+		}
+		body := decodeJSON(t, resp)
+		if body["scope"] != "installation" {
+			t.Errorf("scope = %v, want installation", body["scope"])
+		}
+
+		// AppDef must remain untouched — parse the tools and assert it's still empty
+		updatedApp, err := env.store.GetApp(mktApp.ID)
+		if err != nil {
+			t.Fatalf("GetApp: %v", err)
+		}
+		var appTools []map[string]any
+		if len(updatedApp.Tools) > 0 {
+			json.Unmarshal(updatedApp.Tools, &appTools)
+		}
+		if len(appTools) != 0 {
+			t.Errorf("marketplace app tools should not be modified, got %s", string(updatedApp.Tools))
+		}
+
+		// Installation tools should be set
+		updatedInst, err := env.store.GetInstallation(mktInst.ID)
+		if err != nil {
+			t.Fatalf("GetInstallation: %v", err)
+		}
+		var instTools []map[string]any
+		json.Unmarshal(updatedInst.Tools, &instTools)
+		if len(instTools) != 1 || instTools[0]["name"] != "test" {
+			t.Errorf("installation tools = %v, want [{name:test}]", instTools)
 		}
 	})
 
-	t.Run("update tools fails for builtin app", func(t *testing.T) {
+	t.Run("update tools on builtin app falls back to installation tools", func(t *testing.T) {
 		// Create builtin app
 		biScopes, _ := json.Marshal([]string{"tools:write"})
 		biApp, err := env.store.CreateApp(&store.App{
@@ -1547,8 +1576,13 @@ func TestBotAPI_UpdateTools(t *testing.T) {
 			withBearer(biInst.AppToken))
 		defer resp.Body.Close()
 
-		if resp.StatusCode != 403 {
-			t.Fatalf("expected 403, got %d", resp.StatusCode)
+		if resp.StatusCode != 200 {
+			body := decodeJSON(t, resp)
+			t.Fatalf("expected 200, got %d: %v", resp.StatusCode, body)
+		}
+		body := decodeJSON(t, resp)
+		if body["scope"] != "installation" {
+			t.Errorf("scope = %v, want installation", body["scope"])
 		}
 	})
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1474,6 +1474,9 @@ func TestBotAPI_UpdateTools(t *testing.T) {
 		if body["tool_count"] != float64(2) {
 			t.Errorf("tool_count = %v, want 2", body["tool_count"])
 		}
+		if body["scope"] != "app" {
+			t.Errorf("scope = %v, want app", body["scope"])
+		}
 
 		// Verify tools were actually updated
 		updated, err := env.store.GetApp(app.ID)
@@ -1538,7 +1541,9 @@ func TestBotAPI_UpdateTools(t *testing.T) {
 		}
 		var appTools []map[string]any
 		if len(updatedApp.Tools) > 0 {
-			json.Unmarshal(updatedApp.Tools, &appTools)
+			if err := json.Unmarshal(updatedApp.Tools, &appTools); err != nil {
+				t.Fatalf("unmarshal app tools: %v", err)
+			}
 		}
 		if len(appTools) != 0 {
 			t.Errorf("marketplace app tools should not be modified, got %s", string(updatedApp.Tools))
@@ -1550,7 +1555,9 @@ func TestBotAPI_UpdateTools(t *testing.T) {
 			t.Fatalf("GetInstallation: %v", err)
 		}
 		var instTools []map[string]any
-		json.Unmarshal(updatedInst.Tools, &instTools)
+		if err := json.Unmarshal(updatedInst.Tools, &instTools); err != nil {
+			t.Fatalf("unmarshal installation tools: %v", err)
+		}
 		if len(instTools) != 1 || instTools[0]["name"] != "test" {
 			t.Errorf("installation tools = %v, want [{name:test}]", instTools)
 		}

--- a/internal/api/bot_api.go
+++ b/internal/api/bot_api.go
@@ -371,7 +371,13 @@ func base64Decode(s string) ([]byte, string, error) {
 
 // handleBotAPIUpdateTools handles PUT /bot/v1/app/tools.
 // App dynamically updates its own tools. Requires tools:write scope.
-// Only works for local apps (registry="").
+//
+// For local apps (registry=""), updates the app-level tools shared by all
+// installations. For marketplace/builtin apps the AppDef is immutable, so we
+// transparently fall back to per-installation tools — the natural place for
+// per-user tool registration (e.g. each Runner installation has its own
+// commands). This keeps existing marketplace app clients working without
+// requiring them to know about the app-vs-installation distinction.
 func (s *Server) handleBotAPIUpdateTools(w http.ResponseWriter, r *http.Request) {
 	inst := installationFromContext(r.Context())
 	if inst == nil {
@@ -385,14 +391,12 @@ func (s *Server) handleBotAPIUpdateTools(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Get app and verify it's a local app (not marketplace/builtin)
+	// Look up the app to decide whether to write app-level or installation-level
+	// tools. We treat a missing app as a real error (shouldn't happen since the
+	// installation references it).
 	app, err := s.Store.GetApp(inst.AppID)
 	if err != nil {
 		botAPIError(w, "app not found", http.StatusNotFound)
-		return
-	}
-	if app.Registry != "" {
-		botAPIError(w, "marketplace and builtin apps cannot be modified via API", http.StatusForbidden)
 		return
 	}
 
@@ -411,17 +415,28 @@ func (s *Server) handleBotAPIUpdateTools(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Update the app's tools
-	if err := s.Store.UpdateAppTools(app.ID, req.Tools); err != nil {
-		botAPIError(w, "update failed", http.StatusInternalServerError)
-		return
+	// Marketplace/builtin apps can't mutate the shared AppDef — redirect to
+	// per-installation tools instead.
+	scope := "app"
+	if app.Registry != "" {
+		scope = "installation"
+		if err := s.Store.UpdateInstallationTools(inst.ID, req.Tools); err != nil {
+			botAPIError(w, "update failed", http.StatusInternalServerError)
+			return
+		}
+		slog.Info("marketplace app tools update redirected to installation",
+			"app_id", app.ID, "app_slug", app.Slug, "installation_id", inst.ID,
+			"registry", app.Registry, "tool_count", len(toolsCheck))
+	} else {
+		if err := s.Store.UpdateAppTools(app.ID, req.Tools); err != nil {
+			botAPIError(w, "update failed", http.StatusInternalServerError)
+			return
+		}
+		slog.Info("app tools updated via bot API", "app_id", app.ID, "app_slug", app.Slug, "tool_count", len(toolsCheck))
 	}
 
-	// Log the update
-	slog.Info("app tools updated via bot API", "app_id", app.ID, "app_slug", app.Slug, "tool_count", len(toolsCheck))
-
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"ok": true, "tool_count": len(toolsCheck)})
+	json.NewEncoder(w).Encode(map[string]any{"ok": true, "tool_count": len(toolsCheck), "scope": scope})
 }
 
 // handleBotAPIUpdateInstallationTools handles PUT /bot/v1/installation/tools.


### PR DESCRIPTION
Fixes #246.

## 问题

Marketplace / builtin 应用(`app.Registry != ""`)调用 `PUT /bot/v1/app/tools` 一律 403:

```go
if app.Registry != "" {
    botAPIError(w, "marketplace and builtin apps cannot be modified via API", http.StatusForbidden)
    return
}
```

但官方源 App(如 Runner 类工具)启动时**必须**注册一批命令到 Hub,否则装了等于没装 — 这正是 issue 报告者遇到的情况(高德地图、天气等装好后无法使用)。

## 修复

对 marketplace / builtin 应用,把 `PUT /bot/v1/app/tools` 的写入透明地改写到该 installation 的 tools 表:

- 语义正确:Marketplace 的 AppDef 本来就不该被运行时 API 修改;per-user 注册命令本来就该走 installation 级(每个用户安装独立)。
- 客户端零改动:已发布的官方 App 客户端继续调用同一个端点即可工作。
- 命令派发不变:dispatch 时本来就会合并 App.Tools 和 Installation.Tools(见 `docs/app-development.md` 的 "App-level vs Installation-level Tools")。
- 响应新增 `"scope": "app" | "installation"` 字段,客户端可以判断写到哪一层。

## 测试

- 新增两个子用例覆盖 marketplace / builtin 应用的回退分支
- 验证 AppDef 不被改动 + installation tools 被正确写入
- `scope:write` 缺失仍然 403、非数组 tools 仍然 400 等既有断言保留
- `internal/api` 全包测试通过(4.9s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool updates via PUT /bot/v1/app/tools now supported for marketplace and builtin apps as well as local apps.
  * API responses include a scope field indicating whether the update applies at the app or installation level.

* **Documentation**
  * Updated endpoint docs to clarify routing and the differing response scope for marketplace/builtin vs local apps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openilink/openilink-hub/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->