### PR TITLE
docs: give Windows users a clear Docker / WSL2 path (#241)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ docker run -d -p 9800:9800 ghcr.io/openilink/openilink-hub:latest     # GHCR
 
 > 默认用 SQLite，不用装数据库，不用配任何东西。想用 PostgreSQL？设个 `DATABASE_URL` 就行。
 
+<a id="windows"></a>
+> **Windows 用户**：原生 Windows 不支持，请用以下任一方式：
+> - **Docker（推荐）**：`docker run -d -p 9800:9800 openilink/openilink-hub:latest`
+> - **WSL2**：在 WSL 的 Ubuntu/Debian 里按上面的 Linux 方式跑
+
 ---
 
 ## 这是什么？

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,11 @@ detect_os() {
     case "$(uname -s)" in
         Linux*)  echo "linux" ;;
         Darwin*) echo "darwin" ;;
-        *)       error "Unsupported OS: $(uname -s). Only Linux and macOS are supported." ;;
+        MINGW*|MSYS*|CYGWIN*|Windows_NT|Windows*)
+            error "Windows native install is not supported. Run inside WSL2, or use Docker:
+    docker run -d -p 9800:9800 openilink/openilink-hub:latest
+See https://github.com/${REPO}#windows for details." ;;
+        *)       error "Unsupported OS: $(uname -s). Supported: Linux, macOS (or Docker on any platform)." ;;
     esac
 }
 


### PR DESCRIPTION
Closes #241.

## 问题

Windows 11 用户跑不起来。`install.sh` 对非 Linux/macOS 一律抛 `Unsupported OS`,没告诉用户该走 Docker 或 WSL2。

## 改动

- **`install.sh`**: 显式匹配 `MINGW*` / `MSYS*` / `CYGWIN*` / `Windows_NT`(Git Bash / MSYS2 / Cygwin 各种壳子下 `uname -s` 的输出),返回带具体指引的错误,链接到 README 的 `#windows` 锚点
- **`README.md`**: 在快速开始的安装段后加一行 Windows 用户提示(Docker / WSL2 二选一),加 `<a id="windows">` 锚点

## 验证

```
# Linux 仍然正常
$ uname() { echo Linux; }; ...detect_os
linux

# 模拟 Windows (MINGW64)
$ PATH=stub-uname-mingw:$PATH ...detect_os
error: Windows native install is not supported. Run inside WSL2, or use Docker:
    docker run -d -p 9800:9800 openilink/openilink-hub:latest
See https://github.com/openilink/openilink-hub#windows for details.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start section with Windows setup guidance, recommending Docker or WSL2 as alternatives to native Windows installation.

* **User Experience**
  * Enhanced installation script with Windows detection that provides helpful guidance directing users to Docker or WSL2 options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openilink/openilink-hub/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->