### PR TITLE
feat: optional @handle prefix on outbound replies (#248)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ runner.yaml
 dist/
 .worktrees/
 .claude/worktrees/
+.claude/scheduled_tasks.lock

--- a/integration_test.go
+++ b/integration_test.go
@@ -2917,7 +2917,7 @@ func TestAppEventDelivery_HTTPAndWebSocket(t *testing.T) {
 	}
 	// Grant scopes — handleInstallApp does this via UpdateInstallation; direct
 	// db.InstallApp leaves scopes as "[]", which fails instHasScope checks.
-	if err := env.db.UpdateInstallation(inst.ID, "", inst.Config, appObj.Scopes, true); err != nil {
+	if err := env.db.UpdateInstallation(inst.ID, "", inst.Config, appObj.Scopes, true, false); err != nil {
 		t.Fatalf("UpdateInstallation scopes: %v", err)
 	}
 	time.Sleep(100 * time.Millisecond) // allow bot dispatcher to settle

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -271,8 +271,9 @@ func TestBotAPI_ScopeChecks(t *testing.T) {
 	})
 
 	t.Run("disabled installation returns 403", func(t *testing.T) {
-		// Disable the installation.
-		_ = env.store.UpdateInstallation(instMsgOnly.ID, instMsgOnly.Handle, instMsgOnly.Config, instMsgOnly.Scopes, false, false)
+		// Disable the installation. Preserve ReplyPrefixHandle so this subtest
+		// only toggles the Enabled bit (matches the WS test pattern).
+		_ = env.store.UpdateInstallation(instMsgOnly.ID, instMsgOnly.Handle, instMsgOnly.Config, instMsgOnly.Scopes, false, instMsgOnly.ReplyPrefixHandle)
 
 		resp := doJSON(t, env.ts, "POST", "/bot/v1/message/send",
 			map[string]string{"content": "hello"},
@@ -283,7 +284,7 @@ func TestBotAPI_ScopeChecks(t *testing.T) {
 		}
 
 		// Re-enable for other tests.
-		_ = env.store.UpdateInstallation(instMsgOnly.ID, instMsgOnly.Handle, instMsgOnly.Config, instMsgOnly.Scopes, true, false)
+		_ = env.store.UpdateInstallation(instMsgOnly.ID, instMsgOnly.Handle, instMsgOnly.Config, instMsgOnly.Scopes, true, instMsgOnly.ReplyPrefixHandle)
 	})
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -155,7 +155,7 @@ func installTestApp(t *testing.T, s store.Store, appID, botID string) *store.App
 	// Snapshot app scopes at install time (Slack model)
 	app, err := s.GetApp(appID)
 	if err == nil && app != nil && len(app.Scopes) > 0 {
-		_ = s.UpdateInstallation(inst.ID, inst.Handle, inst.Config, app.Scopes, inst.Enabled)
+		_ = s.UpdateInstallation(inst.ID, inst.Handle, inst.Config, app.Scopes, inst.Enabled, inst.ReplyPrefixHandle)
 		inst.Scopes = app.Scopes
 	}
 	return inst
@@ -269,7 +269,7 @@ func TestBotAPI_ScopeChecks(t *testing.T) {
 
 	t.Run("disabled installation returns 403", func(t *testing.T) {
 		// Disable the installation.
-		_ = env.store.UpdateInstallation(instMsgOnly.ID, instMsgOnly.Handle, instMsgOnly.Config, instMsgOnly.Scopes, false)
+		_ = env.store.UpdateInstallation(instMsgOnly.ID, instMsgOnly.Handle, instMsgOnly.Config, instMsgOnly.Scopes, false, false)
 
 		resp := doJSON(t, env.ts, "POST", "/bot/v1/message/send",
 			map[string]string{"content": "hello"},
@@ -280,7 +280,7 @@ func TestBotAPI_ScopeChecks(t *testing.T) {
 		}
 
 		// Re-enable for other tests.
-		_ = env.store.UpdateInstallation(instMsgOnly.ID, instMsgOnly.Handle, instMsgOnly.Config, instMsgOnly.Scopes, true)
+		_ = env.store.UpdateInstallation(instMsgOnly.ID, instMsgOnly.Handle, instMsgOnly.Config, instMsgOnly.Scopes, true, false)
 	})
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -152,10 +152,13 @@ func installTestApp(t *testing.T, s store.Store, appID, botID string) *store.App
 	if err != nil {
 		t.Fatalf("InstallApp: %v", err)
 	}
-	// Snapshot app scopes at install time (Slack model)
+	// Snapshot app scopes at install time (Slack model). Fail fast so the
+	// helper never hands back an installation with stale scopes.
 	app, err := s.GetApp(appID)
 	if err == nil && app != nil && len(app.Scopes) > 0 {
-		_ = s.UpdateInstallation(inst.ID, inst.Handle, inst.Config, app.Scopes, inst.Enabled, inst.ReplyPrefixHandle)
+		if err := s.UpdateInstallation(inst.ID, inst.Handle, inst.Config, app.Scopes, inst.Enabled, inst.ReplyPrefixHandle); err != nil {
+			t.Fatalf("installTestApp: snapshot scopes: %v", err)
+		}
 		inst.Scopes = app.Scopes
 	}
 	return inst

--- a/internal/api/app_install_handler.go
+++ b/internal/api/app_install_handler.go
@@ -73,9 +73,10 @@ func (s *Server) handleUpdateInstallation(w http.ResponseWriter, r *http.Request
 	}
 
 	var req struct {
-		Handle  *string         `json:"handle"`
-		Config  json.RawMessage `json:"config"`
-		Enabled *bool           `json:"enabled"`
+		Handle            *string         `json:"handle"`
+		Config            json.RawMessage `json:"config"`
+		Enabled           *bool           `json:"enabled"`
+		ReplyPrefixHandle *bool           `json:"reply_prefix_handle"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, "invalid request", http.StatusBadRequest)
@@ -102,8 +103,12 @@ func (s *Server) handleUpdateInstallation(w http.ResponseWriter, r *http.Request
 	if req.Enabled != nil {
 		enabled = *req.Enabled
 	}
+	replyPrefixHandle := inst.ReplyPrefixHandle
+	if req.ReplyPrefixHandle != nil {
+		replyPrefixHandle = *req.ReplyPrefixHandle
+	}
 
-	if err := s.Store.UpdateInstallation(inst.ID, handle, cfg, inst.Scopes, enabled); err != nil {
+	if err := s.Store.UpdateInstallation(inst.ID, handle, cfg, inst.Scopes, enabled, replyPrefixHandle); err != nil {
 		jsonError(w, "update failed", http.StatusInternalServerError)
 		return
 	}
@@ -320,7 +325,7 @@ func (s *Server) handleReauthorize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update installation scopes to current app scopes
-	if err := s.Store.UpdateInstallation(inst.ID, inst.Handle, inst.Config, app.Scopes, inst.Enabled); err != nil {
+	if err := s.Store.UpdateInstallation(inst.ID, inst.Handle, inst.Config, app.Scopes, inst.Enabled, inst.ReplyPrefixHandle); err != nil {
 		jsonError(w, "reauthorize failed", http.StatusInternalServerError)
 		return
 	}
@@ -454,7 +459,7 @@ func (s *Server) handleInstallApp(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "install failed", http.StatusInternalServerError)
 		return
 	}
-	if err := s.Store.UpdateInstallation(inst.ID, req.Handle, inst.Config, scopes, inst.Enabled); err != nil {
+	if err := s.Store.UpdateInstallation(inst.ID, req.Handle, inst.Config, scopes, inst.Enabled, inst.ReplyPrefixHandle); err != nil {
 		slog.Error("install: set handle/scopes failed", "inst", inst.ID, "err", err)
 	}
 	inst.Handle = req.Handle

--- a/internal/api/app_oauth_handler.go
+++ b/internal/api/app_oauth_handler.go
@@ -140,7 +140,7 @@ func (s *Server) handleAppOAuthExchange(w http.ResponseWriter, r *http.Request) 
 	// Snapshot app scopes at install time (Slack model)
 	if len(inst.Scopes) == 0 || string(inst.Scopes) == "[]" || string(inst.Scopes) == "null" {
 		if len(app.Scopes) > 0 {
-			if err := s.Store.UpdateInstallation(inst.ID, inst.Handle, inst.Config, app.Scopes, inst.Enabled); err != nil {
+			if err := s.Store.UpdateInstallation(inst.ID, inst.Handle, inst.Config, app.Scopes, inst.Enabled, inst.ReplyPrefixHandle); err != nil {
 				slog.Error("oauth exchange: snapshot scopes failed", "inst", inst.ID, "err", err)
 			}
 			inst.Scopes = app.Scopes

--- a/internal/api/bot_api.go
+++ b/internal/api/bot_api.go
@@ -26,6 +26,21 @@ func generateTraceID() string {
 	return "tr_" + hex.EncodeToString(b)
 }
 
+// applyReplyPrefix optionally prepends "@{handle} " to outbound text when the
+// installation has opted into multi-channel reply prefixing (#248). A no-op
+// when the toggle is off, the handle is empty, or the prefix is already
+// present (idempotent for clients that pre-format their own messages).
+func applyReplyPrefix(inst *store.AppInstallation, text string) string {
+	if !inst.ReplyPrefixHandle || inst.Handle == "" {
+		return text
+	}
+	prefix := "@" + inst.Handle + " "
+	if strings.HasPrefix(text, prefix) {
+		return text
+	}
+	return prefix + text
+}
+
 // handleBotAPISend handles POST /bot/v1/messages/send.
 func (s *Server) handleBotAPISend(w http.ResponseWriter, r *http.Request) {
 	inst := installationFromContext(r.Context())
@@ -112,7 +127,7 @@ func (s *Server) handleBotAPISend(w http.ResponseWriter, r *http.Request) {
 
 	itemType := req.Type
 	if req.Type == "text" {
-		outMsg.Text = req.Content
+		outMsg.Text = applyReplyPrefix(inst, req.Content)
 	} else {
 		// Media message: resolve data from base64, url, or content
 		var mediaData []byte
@@ -140,7 +155,7 @@ func (s *Server) handleBotAPISend(w http.ResponseWriter, r *http.Request) {
 			}
 		} else {
 			// Fallback: send content as text
-			outMsg.Text = req.Content
+			outMsg.Text = applyReplyPrefix(inst, req.Content)
 			itemType = "text"
 		}
 		if mediaData != nil {

--- a/internal/api/bot_api_ws_test.go
+++ b/internal/api/bot_api_ws_test.go
@@ -121,7 +121,11 @@ func TestBotAPIWebSocket_Connect(t *testing.T) {
 	})
 
 	t.Run("connect with disabled installation", func(t *testing.T) {
-		_ = srv.Store.UpdateInstallation(inst.ID, inst.Handle, inst.Config, inst.Scopes, false, false)
+		// Only flip Enabled; preserve all other settings (including ReplyPrefixHandle)
+		// so the subtest stays focused on the disabled-installation code path.
+		if err := srv.Store.UpdateInstallation(inst.ID, inst.Handle, inst.Config, inst.Scopes, false, inst.ReplyPrefixHandle); err != nil {
+			t.Fatalf("UpdateInstallation(disable): %v", err)
+		}
 
 		wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/bot/v1/ws?token=" + inst.AppToken
 		_, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
@@ -133,7 +137,9 @@ func TestBotAPIWebSocket_Connect(t *testing.T) {
 		}
 
 		// Re-enable
-		_ = srv.Store.UpdateInstallation(inst.ID, inst.Handle, inst.Config, inst.Scopes, true, false)
+		if err := srv.Store.UpdateInstallation(inst.ID, inst.Handle, inst.Config, inst.Scopes, true, inst.ReplyPrefixHandle); err != nil {
+			t.Fatalf("UpdateInstallation(re-enable): %v", err)
+		}
 	})
 }
 

--- a/internal/api/bot_api_ws_test.go
+++ b/internal/api/bot_api_ws_test.go
@@ -121,7 +121,7 @@ func TestBotAPIWebSocket_Connect(t *testing.T) {
 	})
 
 	t.Run("connect with disabled installation", func(t *testing.T) {
-		_ = srv.Store.UpdateInstallation(inst.ID, inst.Handle, inst.Config, inst.Scopes, false)
+		_ = srv.Store.UpdateInstallation(inst.ID, inst.Handle, inst.Config, inst.Scopes, false, false)
 
 		wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/bot/v1/ws?token=" + inst.AppToken
 		_, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
@@ -133,7 +133,7 @@ func TestBotAPIWebSocket_Connect(t *testing.T) {
 		}
 
 		// Re-enable
-		_ = srv.Store.UpdateInstallation(inst.ID, inst.Handle, inst.Config, inst.Scopes, true)
+		_ = srv.Store.UpdateInstallation(inst.ID, inst.Handle, inst.Config, inst.Scopes, true, false)
 	})
 }
 

--- a/internal/api/media_handler_test.go
+++ b/internal/api/media_handler_test.go
@@ -126,7 +126,7 @@ func setupMediaTestEnv(t *testing.T) (*httptest.Server, store.Store, *store.Bot,
 		t.Fatalf("InstallApp: %v", err)
 	}
 	// Grant message:read scope so Bearer auth passes scope check.
-	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), scopesJSON, true); err != nil {
+	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), scopesJSON, true, false); err != nil {
 		t.Fatalf("UpdateInstallation: %v", err)
 	}
 	// Re-read to pick up updated scopes.
@@ -277,7 +277,7 @@ func TestChannelMedia_BearerDisabledInstallation(t *testing.T) {
 
 	// Disable the installation.
 	scopesJSON, _ := json.Marshal([]string{"message:read"})
-	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), scopesJSON, false); err != nil {
+	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), scopesJSON, false, false); err != nil {
 		t.Fatalf("UpdateInstallation: %v", err)
 	}
 
@@ -298,7 +298,7 @@ func TestChannelMedia_BearerNoScope(t *testing.T) {
 	ts, s, _, inst := setupMediaTestEnv(t)
 
 	// Clear scopes on the installation.
-	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), json.RawMessage("[]"), true); err != nil {
+	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), json.RawMessage("[]"), true, false); err != nil {
 		t.Fatalf("UpdateInstallation: %v", err)
 	}
 
@@ -320,7 +320,7 @@ func TestMediaProxy_BearerDisabledInstallation(t *testing.T) {
 
 	// Disable the installation.
 	scopesJSON, _ := json.Marshal([]string{"message:read"})
-	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), scopesJSON, false); err != nil {
+	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), scopesJSON, false, false); err != nil {
 		t.Fatalf("UpdateInstallation: %v", err)
 	}
 
@@ -341,7 +341,7 @@ func TestMediaProxy_BearerNoScope(t *testing.T) {
 	ts, s, b, inst := setupMediaTestEnv(t)
 
 	// Clear scopes on the installation.
-	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), json.RawMessage("[]"), true); err != nil {
+	if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), json.RawMessage("[]"), true, false); err != nil {
 		t.Fatalf("UpdateInstallation: %v", err)
 	}
 

--- a/internal/api/reply_prefix_test.go
+++ b/internal/api/reply_prefix_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/openilink/openilink-hub/internal/store"
+)
+
+// TestApplyReplyPrefix covers the per-installation reply-prefix behavior
+// introduced for #248: when ReplyPrefixHandle is on and Handle is non-empty,
+// outbound text gets "@handle " prepended; otherwise text is unchanged.
+func TestApplyReplyPrefix(t *testing.T) {
+	cases := []struct {
+		name string
+		inst *store.AppInstallation
+		text string
+		want string
+	}{
+		{
+			name: "disabled — no prefix",
+			inst: &store.AppInstallation{Handle: "claw", ReplyPrefixHandle: false},
+			text: "hello",
+			want: "hello",
+		},
+		{
+			name: "enabled with handle — prepends",
+			inst: &store.AppInstallation{Handle: "claw", ReplyPrefixHandle: true},
+			text: "hello",
+			want: "@claw hello",
+		},
+		{
+			name: "enabled but handle empty — no prefix",
+			inst: &store.AppInstallation{Handle: "", ReplyPrefixHandle: true},
+			text: "hello",
+			want: "hello",
+		},
+		{
+			name: "idempotent — already prefixed, leaves alone",
+			inst: &store.AppInstallation{Handle: "claw", ReplyPrefixHandle: true},
+			text: "@claw hello",
+			want: "@claw hello",
+		},
+		{
+			name: "different handle in text — still prefixes (no false match)",
+			inst: &store.AppInstallation{Handle: "claw", ReplyPrefixHandle: true},
+			text: "@other hello",
+			want: "@claw @other hello",
+		},
+		{
+			name: "empty text — only prefix",
+			inst: &store.AppInstallation{Handle: "claw", ReplyPrefixHandle: true},
+			text: "",
+			want: "@claw ",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyReplyPrefix(tc.inst, tc.text)
+			if got != tc.want {
+				t.Errorf("applyReplyPrefix(%q) = %q, want %q", tc.text, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/store/app.go
+++ b/internal/store/app.go
@@ -51,8 +51,11 @@ type AppInstallation struct {
 	Scopes    json.RawMessage `json:"scopes"`
 	Tools     json.RawMessage `json:"tools,omitempty"`
 	Enabled   bool            `json:"enabled"`
-	CreatedAt int64           `json:"created_at"`
-	UpdatedAt int64           `json:"updated_at"`
+	// ReplyPrefixHandle, when true, makes the Bot API send path prepend
+	// "@{handle} " to outgoing text messages. Opt-in (default false). See #248.
+	ReplyPrefixHandle bool  `json:"reply_prefix_handle"`
+	CreatedAt         int64 `json:"created_at"`
+	UpdatedAt         int64 `json:"updated_at"`
 
 	// Joined from apps table
 	AppName          string `json:"app_name,omitempty"`
@@ -118,7 +121,7 @@ type AppStore interface {
 	GetInstallationByToken(token string) (*AppInstallation, error)
 	ListInstallationsByApp(appID string) ([]AppInstallation, error)
 	ListInstallationsByBot(botID string) ([]AppInstallation, error)
-	UpdateInstallation(id, handle string, config json.RawMessage, scopes json.RawMessage, enabled bool) error
+	UpdateInstallation(id, handle string, config json.RawMessage, scopes json.RawMessage, enabled bool, replyPrefixHandle bool) error
 	SetAppWebhookVerified(id string, verified bool) error
 	UpdateAppWebhookURL(id, webhookURL string) error
 	InstalledAppIDs(userID string) (map[string]bool, error)

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -420,7 +420,7 @@ func (s *Store) InstallApp(string, string) (*store.AppInstallation, error) {
 }
 func (s *Store) InstalledAppIDs(string) (map[string]bool, error)                { return nil, nil }
 func (s *Store) ListInstallationsByApp(string) ([]store.AppInstallation, error) { return nil, nil }
-func (s *Store) UpdateInstallation(string, string, json.RawMessage, json.RawMessage, bool) error {
+func (s *Store) UpdateInstallation(string, string, json.RawMessage, json.RawMessage, bool, bool) error {
 	return nil
 }
 func (s *Store) SetAppWebhookVerified(string, bool) error           { return nil }

--- a/internal/store/postgres/app.go
+++ b/internal/store/postgres/app.go
@@ -299,7 +299,7 @@ func (db *DB) InstallApp(appID, botID string) (*store.AppInstallation, error) {
 func (db *DB) GetInstallation(id string) (*store.AppInstallation, error) {
 	i := &store.AppInstallation{}
 	err := db.QueryRow(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.tools, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled, i.reply_prefix_handle,
 		EXTRACT(EPOCH FROM i.created_at)::BIGINT, EXTRACT(EPOCH FROM i.updated_at)::BIGINT,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -307,7 +307,7 @@ func (db *DB) GetInstallation(id string) (*store.AppInstallation, error) {
 		FROM app_installations i JOIN apps a ON a.id = i.app_id
 		WHERE i.id = $1`, id).Scan(
 		&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
+		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled, &i.ReplyPrefixHandle,
 		&i.CreatedAt, &i.UpdatedAt,
 		&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 		&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -321,7 +321,7 @@ func (db *DB) GetInstallation(id string) (*store.AppInstallation, error) {
 func (db *DB) GetInstallationByToken(token string) (*store.AppInstallation, error) {
 	i := &store.AppInstallation{}
 	err := db.QueryRow(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.tools, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled, i.reply_prefix_handle,
 		EXTRACT(EPOCH FROM i.created_at)::BIGINT, EXTRACT(EPOCH FROM i.updated_at)::BIGINT,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -329,7 +329,7 @@ func (db *DB) GetInstallationByToken(token string) (*store.AppInstallation, erro
 		FROM app_installations i JOIN apps a ON a.id = i.app_id
 		WHERE i.app_token = $1`, token).Scan(
 		&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
+		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled, &i.ReplyPrefixHandle,
 		&i.CreatedAt, &i.UpdatedAt,
 		&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 		&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -368,7 +368,7 @@ func (db *DB) ListInstallationsByBot(botID string) ([]store.AppInstallation, err
 
 func (db *DB) listInstallations(where string, arg any) ([]store.AppInstallation, error) {
 	rows, err := db.Query(fmt.Sprintf(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.tools, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled, i.reply_prefix_handle,
 		EXTRACT(EPOCH FROM i.created_at)::BIGINT, EXTRACT(EPOCH FROM i.updated_at)::BIGINT,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -383,7 +383,7 @@ func (db *DB) listInstallations(where string, arg any) ([]store.AppInstallation,
 	for rows.Next() {
 		var i store.AppInstallation
 		if err := rows.Scan(&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-			&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
+			&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled, &i.ReplyPrefixHandle,
 			&i.CreatedAt, &i.UpdatedAt,
 			&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 			&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -395,9 +395,10 @@ func (db *DB) listInstallations(where string, arg any) ([]store.AppInstallation,
 	return list, rows.Err()
 }
 
-func (db *DB) UpdateInstallation(id, handle string, config json.RawMessage, scopes json.RawMessage, enabled bool) error {
-	_, err := db.Exec(`UPDATE app_installations SET handle=$1, config=$2, scopes=$3, enabled=$4, updated_at=$5 WHERE id=$6`,
-		handle, config, scopes, enabled, db.now(), id)
+func (db *DB) UpdateInstallation(id, handle string, config json.RawMessage, scopes json.RawMessage, enabled bool, replyPrefixHandle bool) error {
+	_, err := db.Exec(`UPDATE app_installations
+		SET handle=$1, config=$2, scopes=$3, enabled=$4, reply_prefix_handle=$5, updated_at=$6 WHERE id=$7`,
+		handle, config, scopes, enabled, replyPrefixHandle, db.now(), id)
 	return err
 }
 
@@ -420,7 +421,7 @@ func (db *DB) RegenerateInstallationToken(id string) (string, error) {
 func (db *DB) GetInstallationByHandle(botID, handle string) (*store.AppInstallation, error) {
 	i := &store.AppInstallation{}
 	err := db.QueryRow(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.tools, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled, i.reply_prefix_handle,
 		EXTRACT(EPOCH FROM i.created_at)::BIGINT, EXTRACT(EPOCH FROM i.updated_at)::BIGINT,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -428,7 +429,7 @@ func (db *DB) GetInstallationByHandle(botID, handle string) (*store.AppInstallat
 		FROM app_installations i JOIN apps a ON a.id = i.app_id
 		WHERE i.bot_id = $1 AND i.handle = $2`, botID, handle).Scan(
 		&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
+		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled, &i.ReplyPrefixHandle,
 		&i.CreatedAt, &i.UpdatedAt,
 		&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 		&i.AppWebhookURL, &i.AppWebhookSecret,

--- a/internal/store/postgres/migrations/0039_installation_reply_prefix.sql
+++ b/internal/store/postgres/migrations/0039_installation_reply_prefix.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- Per-installation flag: when an installation sends a reply through Bot API,
+-- prepend "@{handle} " to text messages so users in multi-channel setups can
+-- tell which channel responded. Default off — opt-in to avoid noise in
+-- single-channel deployments. See issue #248.
+ALTER TABLE app_installations
+    ADD COLUMN IF NOT EXISTS reply_prefix_handle BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- +goose Down
+ALTER TABLE app_installations DROP COLUMN IF EXISTS reply_prefix_handle;

--- a/internal/store/sqlite/app.go
+++ b/internal/store/sqlite/app.go
@@ -306,7 +306,7 @@ func (db *DB) InstallApp(appID, botID string) (*store.AppInstallation, error) {
 func (db *DB) GetInstallation(id string) (*store.AppInstallation, error) {
 	i := &store.AppInstallation{}
 	err := db.QueryRow(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.tools, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled, i.reply_prefix_handle,
 		i.created_at, i.updated_at,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -314,7 +314,7 @@ func (db *DB) GetInstallation(id string) (*store.AppInstallation, error) {
 		FROM app_installations i JOIN apps a ON a.id = i.app_id
 		WHERE i.id = ?`, id).Scan(
 		&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
+		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled, &i.ReplyPrefixHandle,
 		&i.CreatedAt, &i.UpdatedAt,
 		&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 		&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -328,7 +328,7 @@ func (db *DB) GetInstallation(id string) (*store.AppInstallation, error) {
 func (db *DB) GetInstallationByToken(token string) (*store.AppInstallation, error) {
 	i := &store.AppInstallation{}
 	err := db.QueryRow(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.tools, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled, i.reply_prefix_handle,
 		i.created_at, i.updated_at,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -336,7 +336,7 @@ func (db *DB) GetInstallationByToken(token string) (*store.AppInstallation, erro
 		FROM app_installations i JOIN apps a ON a.id = i.app_id
 		WHERE i.app_token = ?`, token).Scan(
 		&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
+		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled, &i.ReplyPrefixHandle,
 		&i.CreatedAt, &i.UpdatedAt,
 		&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 		&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -375,7 +375,7 @@ func (db *DB) ListInstallationsByBot(botID string) ([]store.AppInstallation, err
 
 func (db *DB) listInstallations(where string, arg any) ([]store.AppInstallation, error) {
 	rows, err := db.Query(fmt.Sprintf(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.tools, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled, i.reply_prefix_handle,
 		i.created_at, i.updated_at,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -390,7 +390,7 @@ func (db *DB) listInstallations(where string, arg any) ([]store.AppInstallation,
 	for rows.Next() {
 		var i store.AppInstallation
 		if err := rows.Scan(&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-			&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
+			&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled, &i.ReplyPrefixHandle,
 			&i.CreatedAt, &i.UpdatedAt,
 			&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 			&i.AppWebhookURL, &i.AppWebhookSecret,
@@ -402,9 +402,10 @@ func (db *DB) listInstallations(where string, arg any) ([]store.AppInstallation,
 	return list, rows.Err()
 }
 
-func (db *DB) UpdateInstallation(id, handle string, config json.RawMessage, scopes json.RawMessage, enabled bool) error {
-	_, err := db.Exec(`UPDATE app_installations SET handle=?, config=?, scopes=?, enabled=?, updated_at=? WHERE id=?`,
-		handle, config, scopes, enabled, db.now(), id)
+func (db *DB) UpdateInstallation(id, handle string, config json.RawMessage, scopes json.RawMessage, enabled bool, replyPrefixHandle bool) error {
+	_, err := db.Exec(`UPDATE app_installations
+		SET handle=?, config=?, scopes=?, enabled=?, reply_prefix_handle=?, updated_at=? WHERE id=?`,
+		handle, config, scopes, enabled, replyPrefixHandle, db.now(), id)
 	return err
 }
 
@@ -427,7 +428,7 @@ func (db *DB) RegenerateInstallationToken(id string) (string, error) {
 func (db *DB) GetInstallationByHandle(botID, handle string) (*store.AppInstallation, error) {
 	i := &store.AppInstallation{}
 	err := db.QueryRow(`SELECT i.id, i.app_id, i.bot_id, i.app_token,
-		i.handle, i.config, i.scopes, i.tools, i.enabled,
+		i.handle, i.config, i.scopes, i.tools, i.enabled, i.reply_prefix_handle,
 		i.created_at, i.updated_at,
 		COALESCE(a.name,''), COALESCE(a.slug,''), COALESCE(a.icon,''), COALESCE(a.icon_url,''),
 		a.webhook_url, a.webhook_secret,
@@ -435,7 +436,7 @@ func (db *DB) GetInstallationByHandle(botID, handle string) (*store.AppInstallat
 		FROM app_installations i JOIN apps a ON a.id = i.app_id
 		WHERE i.bot_id = ? AND i.handle = ?`, botID, handle).Scan(
 		&i.ID, &i.AppID, &i.BotID, &i.AppToken,
-		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled,
+		&i.Handle, &i.Config, &i.Scopes, &i.Tools, &i.Enabled, &i.ReplyPrefixHandle,
 		&i.CreatedAt, &i.UpdatedAt,
 		&i.AppName, &i.AppSlug, &i.AppIcon, &i.AppIconURL,
 		&i.AppWebhookURL, &i.AppWebhookSecret,

--- a/internal/store/sqlite/migrations/0010_installation_reply_prefix.sql
+++ b/internal/store/sqlite/migrations/0010_installation_reply_prefix.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- Per-installation flag: when an installation sends a reply through Bot API,
+-- prepend "@{handle} " to text messages so users in multi-channel setups can
+-- tell which channel responded. Default off — opt-in to avoid noise in
+-- single-channel deployments. See issue #248.
+ALTER TABLE app_installations ADD COLUMN reply_prefix_handle BOOLEAN NOT NULL DEFAULT 0;
+
+-- +goose Down
+-- SQLite < 3.35 cannot DROP COLUMN; rollback skipped. The column defaults to 0
+-- so leaving it in place after a downgrade is safe.

--- a/internal/store/storetest/app_lifecycle.go
+++ b/internal/store/storetest/app_lifecycle.go
@@ -483,7 +483,7 @@ func TestAppLifecycle(t *testing.T, s store.Store) {
 	t.Run("UpdateInstallation", func(t *testing.T) {
 		cfg := json.RawMessage(`{"channel":"general"}`)
 		scopes := json.RawMessage(`["message:read"]`)
-		if err := s.UpdateInstallation(instID, "my-app-handle", cfg, scopes, false); err != nil {
+		if err := s.UpdateInstallation(instID, "my-app-handle", cfg, scopes, false, true); err != nil {
 			t.Fatalf("UpdateInstallation: %v", err)
 		}
 		got, _ := s.GetInstallation(instID)
@@ -506,6 +506,9 @@ func TestAppLifecycle(t *testing.T, s store.Store) {
 		}
 		if len(gotScopes) != 1 || gotScopes[0] != "message:read" {
 			t.Errorf("scopes = %s", got.Scopes)
+		}
+		if !got.ReplyPrefixHandle {
+			t.Error("expected reply_prefix_handle=true after update")
 		}
 	})
 
@@ -948,7 +951,7 @@ func TestAppLifecycle(t *testing.T, s store.Store) {
 
 		// Set installation-level scopes (subset of app scopes).
 		instScopes, _ := json.Marshal([]string{"message:read"})
-		if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), instScopes, true); err != nil {
+		if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), instScopes, true, false); err != nil {
 			t.Fatalf("UpdateInstallation: %v", err)
 		}
 
@@ -961,7 +964,7 @@ func TestAppLifecycle(t *testing.T, s store.Store) {
 
 		// Clear installation scopes back to empty.
 		emptyScopes, _ := json.Marshal([]string{})
-		if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), emptyScopes, true); err != nil {
+		if err := s.UpdateInstallation(inst.ID, "", json.RawMessage("{}"), emptyScopes, true, false); err != nil {
 			t.Fatalf("UpdateInstallation (clear scopes): %v", err)
 		}
 		got, _ = s.GetInstallation(inst.ID)

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -1222,7 +1222,7 @@ func TestAppCRUD(t *testing.T, s store.Store) {
 	t.Run("UpdateInstallation", func(t *testing.T) {
 		cfg := json.RawMessage(`{"key":"val"}`)
 		scopes := json.RawMessage(`["message:read"]`)
-		if err := s.UpdateInstallation(instID, "myhandle", cfg, scopes, false); err != nil {
+		if err := s.UpdateInstallation(instID, "myhandle", cfg, scopes, false, false); err != nil {
 			t.Fatalf("UpdateInstallation: %v", err)
 		}
 		got, _ := s.GetInstallation(instID)

--- a/web/src/pages/installation-detail.tsx
+++ b/web/src/pages/installation-detail.tsx
@@ -263,17 +263,23 @@ export function InstallationDetailPage() {
             {app.description ? (
               <p className="text-sm text-muted-foreground">{app.description}</p>
             ) : null}
-            {/* Secondary toggle row: reply-prefix opt-in (#248) */}
+            {/* Secondary toggle row: reply-prefix opt-in (#248). Disabled
+                when handle is empty since the backend short-circuits and
+                wouldn't actually prepend anything. */}
             <div className="flex items-center gap-2 pt-1">
               <Switch
-                checked={replyPrefixHandle}
+                checked={replyPrefixHandle && !!handle}
                 onCheckedChange={handleToggleReplyPrefix}
-                disabled={prefixPending}
+                disabled={prefixPending || !handle}
                 aria-label="回复时带 @handle 前缀"
               />
               <span className="text-sm text-muted-foreground">
                 回复时带 <code className="font-mono">@{handle || "handle"}</code> 前缀
-                <span className="ml-1 text-xs">（多 channel 时区分来源）</span>
+                {handle ? (
+                  <span className="ml-1 text-xs">（多 channel 时区分来源）</span>
+                ) : (
+                  <span className="ml-1 text-xs">（先设置 handle 后可启用）</span>
+                )}
               </span>
             </div>
           </div>

--- a/web/src/pages/installation-detail.tsx
+++ b/web/src/pages/installation-detail.tsx
@@ -120,14 +120,17 @@ export function InstallationDetailPage() {
   const [handle, setHandle] = useState("");
   const [enabled, setEnabled] = useState(true);
   const [enablingPending, setEnablingPending] = useState(false);
+  const [replyPrefixHandle, setReplyPrefixHandle] = useState(false);
+  const [prefixPending, setPrefixPending] = useState(false);
 
   // Sync local state when inst loads
   useEffect(() => {
     if (inst) {
       setHandle(inst.handle || "");
       setEnabled(inst.enabled ?? true);
+      setReplyPrefixHandle(inst.reply_prefix_handle ?? false);
     }
-  }, [inst?.id, inst?.handle, inst?.enabled]);
+  }, [inst?.id, inst?.handle, inst?.enabled, inst?.reply_prefix_handle]);
 
   if (loading) {
     return (
@@ -180,6 +183,21 @@ export function InstallationDetailPage() {
       toast({ variant: "destructive", title: "保存失败", description: e.message });
     } finally {
       setEnablingPending(false);
+    }
+  }
+
+  async function handleToggleReplyPrefix(val: boolean) {
+    if (prefixPending) return;
+    setPrefixPending(true);
+    setReplyPrefixHandle(val);
+    try {
+      await api.updateInstallation(inst.app_id, inst.id, { reply_prefix_handle: val });
+      refreshInstallations();
+    } catch (e: any) {
+      setReplyPrefixHandle(!val);
+      toast({ variant: "destructive", title: "保存失败", description: e.message });
+    } finally {
+      setPrefixPending(false);
     }
   }
 
@@ -245,6 +263,19 @@ export function InstallationDetailPage() {
             {app.description ? (
               <p className="text-sm text-muted-foreground">{app.description}</p>
             ) : null}
+            {/* Secondary toggle row: reply-prefix opt-in (#248) */}
+            <div className="flex items-center gap-2 pt-1">
+              <Switch
+                checked={replyPrefixHandle}
+                onCheckedChange={handleToggleReplyPrefix}
+                disabled={prefixPending}
+                aria-label="回复时带 @handle 前缀"
+              />
+              <span className="text-sm text-muted-foreground">
+                回复时带 <code className="font-mono">@{handle || "handle"}</code> 前缀
+                <span className="ml-1 text-xs">（多 channel 时区分来源）</span>
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -744,7 +775,15 @@ function AppConfigForm({ app, inst, onUpdate }: { app: any; inst: any; onUpdate:
 
 // ==================== Config Section ====================
 
-function ConfigSection({ inst, onUninstall, queryClient }: { inst: any; onUninstall: () => void; queryClient: QueryClient }) {
+function ConfigSection({
+  inst,
+  onUninstall,
+  queryClient,
+}: {
+  inst: any;
+  onUninstall: () => void;
+  queryClient: QueryClient;
+}) {
   const { toast } = useToast();
   const [showUninstallDialog, setShowUninstallDialog] = useState(false);
   const [uninstalling, setUninstalling] = useState(false);
@@ -869,26 +908,30 @@ function EventLogsSection({
       </div>
 
       {/* Show hint when logs contain 403/4xx errors */}
-      {!loading && logs.some((l) => {
-        const code = l.status_code || l.status;
-        return code >= 400 && code < 500;
-      }) && (
-        <div className="rounded-lg border border-orange-200 bg-orange-50 dark:border-orange-900 dark:bg-orange-950/30 p-3 text-xs text-muted-foreground space-y-1">
-          <p className="font-medium text-orange-700 dark:text-orange-400">部分事件投递失败</p>
-          <p>如果应用来自远程市场，4xx 错误通常是远程应用服务器的配置问题。请联系应用开发者确认 Webhook 地址和权限配置是否正确。</p>
-          {homepage ? (
-            <a
-              href={homepage}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-orange-700 hover:underline dark:text-orange-400"
-            >
-              <ExternalLink className="h-3 w-3" />
-              前往应用主页
-            </a>
-          ) : null}
-        </div>
-      )}
+      {!loading &&
+        logs.some((l) => {
+          const code = l.status_code || l.status;
+          return code >= 400 && code < 500;
+        }) && (
+          <div className="rounded-lg border border-orange-200 bg-orange-50 dark:border-orange-900 dark:bg-orange-950/30 p-3 text-xs text-muted-foreground space-y-1">
+            <p className="font-medium text-orange-700 dark:text-orange-400">部分事件投递失败</p>
+            <p>
+              如果应用来自远程市场，4xx 错误通常是远程应用服务器的配置问题。请联系应用开发者确认
+              Webhook 地址和权限配置是否正确。
+            </p>
+            {homepage ? (
+              <a
+                href={homepage}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-orange-700 hover:underline dark:text-orange-400"
+              >
+                <ExternalLink className="h-3 w-3" />
+                前往应用主页
+              </a>
+            ) : null}
+          </div>
+        )}
 
       <Card className="overflow-hidden">
         {loading ? (


### PR DESCRIPTION
Closes #248.

## 背景

部分用户在 1 个 Bot 上挂多个 channel(OpenClaw、Bridge 等),回复时分不清是哪个 channel 响应的。Issue #248 part 1 已通过 `@handle` 路由满足(用户发 `@claw 内容`);part 2 请求:**回复也带上 `@channel` 前缀**。

## 改动

**Per-installation opt-in**(默认关,单 channel 用户零影响)。

- **DB**:`app_installations` 加列 `reply_prefix_handle BOOLEAN NOT NULL DEFAULT FALSE`(postgres `0039` + sqlite `0010`)
- **Store**:`AppInstallation.ReplyPrefixHandle` 字段 + 全部 SELECT/INSERT/UPDATE/`UpdateInstallation` 签名串通
- **API**:`handleBotAPISend` 新增 `applyReplyPrefix(inst, text)` helper,在 text 类型消息和 fallback 路径都应用。`PUT /api/apps/{id}/installations/{iid}` 接受新字段
- **前端**:`installation-detail.tsx` header 加一个小 Switch,toggle `inst.reply_prefix_handle`
- **测试**:`reply_prefix_test.go` 覆盖 6 个分支(关闭 / 开启 / handle 为空 / 已带前缀 idempotent / 不同 handle / 空文本)

## prefix 行为

```
inst.Handle = "claw", inst.ReplyPrefixHandle = true
text:  "hello"           → "@claw hello"
text:  "@claw hello"     → "@claw hello"      (idempotent)
text:  "@other hello"    → "@claw @other hello"
text:  ""                → "@claw "

inst.Handle = "claw", inst.ReplyPrefixHandle = false
text:  "hello"           → "hello"            (no-op)

inst.Handle = "",     inst.ReplyPrefixHandle = true
text:  "hello"           → "hello"            (no handle, no prefix)
```

## 验证

- Backend:`go test ./...` 全绿
- Frontend:`pnpm build` 成功,`pnpm test` 12/12 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-installation "reply with `@handle` prefix" setting; installation page adds a toggle to enable/disable it and persists the choice.
  * Bot text replies will include the handle prefix when enabled for attribution.

* **Bug Fixes**
  * Prefix application is idempotent and avoids double-prefixing; toggles roll back on update failure.

* **Chores**
  * Ignore local lock file to avoid accidental commits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openilink/openilink-hub/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->