### PR TITLE
fix #248: @mention U+2005 路由修复 + 频道回复加【handle】标签

### DIFF
--- a/internal/app/matching.go
+++ b/internal/app/matching.go
@@ -5,9 +5,25 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/openilink/openilink-hub/internal/store"
 )
+
+// SplitFirstField splits s into its first whitespace-delimited field and the
+// trimmed remainder. Unlike strings.SplitN(s, " ", 2) it treats any Unicode
+// whitespace as a separator — notably U+2005 (FOUR-PER-EM SPACE), which WeChat
+// inserts right after an @mention, and the full-width space U+3000. Without this
+// "@handle text" would parse the handle as "handle text" and fail to route.
+func SplitFirstField(s string) (first, rest string) {
+	i := strings.IndexFunc(s, unicode.IsSpace)
+	if i < 0 {
+		return s, ""
+	}
+	_, size := utf8.DecodeRuneInString(s[i:])
+	return s[:i], strings.TrimSpace(s[i+size:])
+}
 
 // ParseMention extracts handle, command, and text from @handle messages.
 // Returns handle, command (with / prefix or empty), remaining text.
@@ -21,21 +37,15 @@ func ParseMention(content string) (handle, command, text string) {
 	if !strings.HasPrefix(content, "@") {
 		return "", "", ""
 	}
-	parts := strings.SplitN(content[1:], " ", 2)
-	handle = strings.ToLower(parts[0])
+	handleRaw, remaining := SplitFirstField(content[1:])
+	handle = strings.ToLower(handleRaw)
 	if handle == "" {
 		return "", "", ""
 	}
-	remaining := ""
-	if len(parts) > 1 {
-		remaining = strings.TrimSpace(parts[1])
-	}
 	if strings.HasPrefix(remaining, "/") {
-		cmdParts := strings.SplitN(remaining[1:], " ", 2)
-		command = "/" + strings.ToLower(cmdParts[0])
-		if len(cmdParts) > 1 {
-			text = strings.TrimSpace(cmdParts[1])
-		}
+		cmd, rest := SplitFirstField(remaining[1:])
+		command = "/" + strings.ToLower(cmd)
+		text = rest
 		return handle, command, text
 	}
 	return handle, "", remaining
@@ -147,12 +157,12 @@ func parseCommand(content string) (string, string) {
 
 	// Skip leading @mention if present.
 	if strings.HasPrefix(content, "@") {
-		idx := strings.IndexByte(content, ' ')
-		if idx < 0 {
+		_, rest := SplitFirstField(content[1:])
+		if rest == "" {
 			// Just a mention, no command.
 			return "", ""
 		}
-		content = strings.TrimSpace(content[idx+1:])
+		content = rest
 	}
 
 	// Must start with "/" to be a command.
@@ -160,17 +170,11 @@ func parseCommand(content string) (string, string) {
 		return "", ""
 	}
 
-	// Split into command and args.
-	content = content[1:] // strip leading "/"
-	parts := strings.SplitN(content, " ", 2)
-	command := strings.ToLower(parts[0])
+	// Split into command and args (strip leading "/").
+	command, args := SplitFirstField(content[1:])
+	command = strings.ToLower(command)
 	if command == "" {
 		return "", ""
-	}
-
-	args := ""
-	if len(parts) > 1 {
-		args = strings.TrimSpace(parts[1])
 	}
 
 	return command, args

--- a/internal/app/matching_test.go
+++ b/internal/app/matching_test.go
@@ -562,3 +562,16 @@ func TestMatchEvent_MultipleInstallations(t *testing.T) {
 		t.Errorf("matched[0].ID = %q, want %q", matched[0].ID, "i1")
 	}
 }
+
+// TestChannelTaggedReplyIsInert guards issue #248 Part 2: the channel-reply
+// prefix uses 【handle】 rather than @handle precisely so that if such a reply
+// ever echoes back as inbound it is NOT re-parsed as a mention or command
+// (which would risk a routing loop).
+func TestChannelTaggedReplyIsInert(t *testing.T) {
+	if h, c, txt := ParseMention("【openclaw】 hello"); h != "" || c != "" || txt != "" {
+		t.Errorf("ParseMention(【openclaw】...) = (%q, %q, %q), want all empty", h, c, txt)
+	}
+	if cmd, _ := parseCommand("【openclaw】 /deploy prod"); cmd != "" {
+		t.Errorf("parseCommand(【openclaw】 /deploy) cmd = %q, want empty", cmd)
+	}
+}

--- a/internal/app/matching_test.go
+++ b/internal/app/matching_test.go
@@ -436,6 +436,41 @@ func TestParseMention(t *testing.T) {
 	}
 }
 
+// TestParseMention_UnicodeWhitespace verifies that handles still parse when the
+// separator after @handle is not an ASCII space. WeChat inserts U+2005 (FOUR-PER-EM
+// SPACE) right after an @mention, and some clients use a full-width space (U+3000).
+func TestParseMention_UnicodeWhitespace(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		handle  string
+		command string
+		text    string
+	}{
+		{"four-per-em space (WeChat @)", "@echo-work hello", "echo-work", "", "hello"},
+		{"full-width space", "@echo-work　hello", "echo-work", "", "hello"},
+		{"four-per-em then command", "@echo-work /echo hi", "echo-work", "/echo", "hi"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handle, command, text := ParseMention(tt.input)
+			if handle != tt.handle || command != tt.command || text != tt.text {
+				t.Errorf("ParseMention(%q) = (%q, %q, %q), want (%q, %q, %q)",
+					tt.input, handle, command, text, tt.handle, tt.command, tt.text)
+			}
+		})
+	}
+}
+
+// TestParseCommand_UnicodeWhitespace locks the second parsing path: a U+2005
+// separator between an @mention and the following /command must still parse.
+func TestParseCommand_UnicodeWhitespace(t *testing.T) {
+	cmd, args := parseCommand("@echo-work /deploy prod")
+	if cmd != "deploy" || args != "prod" {
+		t.Errorf("parseCommand(@echo-work\\u2005/deploy prod) = (%q, %q), want (deploy, prod)", cmd, args)
+	}
+}
+
 // ==================== MatchHandle tests ====================
 
 func TestMatchHandle_Success(t *testing.T) {

--- a/internal/bot/app_dispatch.go
+++ b/internal/bot/app_dispatch.go
@@ -196,7 +196,7 @@ func (m *Manager) deliverEventToApp(inst *Instance, installation *store.AppInsta
 		} else {
 			span.EndWithError("no result")
 		}
-		m.sendAppResult(inst, sender, result, tracer, rootSpan)
+		m.sendAppResult(inst, installation, sender, result, tracer, rootSpan)
 	}
 }
 
@@ -236,8 +236,27 @@ func (m *Manager) tryDeliverCommand(inst *Instance, msg provider.InboundMessage,
 	return true
 }
 
+// channelTag returns a short display prefix identifying which channel/app
+// produced a reply, so users can tell replies apart when several channels are
+// active (issue #248). It prefers the channel handle (falling back to the app
+// name) and deliberately does NOT use an "@" prefix: an echoed "@handle" reply
+// could be re-parsed by mention routing and loop, whereas "【handle】" is inert.
+func channelTag(installation *store.AppInstallation) string {
+	if installation == nil {
+		return ""
+	}
+	name := installation.Handle
+	if name == "" {
+		name = installation.AppName
+	}
+	if name == "" {
+		return ""
+	}
+	return "【" + name + "】 "
+}
+
 // sendAppResult sends a reply from an App via the bot and stores it as outbound.
-func (m *Manager) sendAppResult(inst *Instance, to string, result *appdelivery.DeliveryResult, tracer *store.Tracer, rootSpan *store.SpanBuilder) {
+func (m *Manager) sendAppResult(inst *Instance, installation *store.AppInstallation, to string, result *appdelivery.DeliveryResult, tracer *store.Tracer, rootSpan *store.SpanBuilder) {
 	if result == nil || result.ReplyAsync {
 		return
 	}
@@ -262,12 +281,13 @@ func (m *Manager) sendAppResult(inst *Instance, to string, result *appdelivery.D
 		if result.Reply == "" {
 			return
 		}
+		text := channelTag(installation) + result.Reply
 		span := tracer.StartChild(rootSpan, "send_reply", store.SpanKindClient, map[string]any{
 			"reply.type":    "text",
 			"reply.to":      to,
-			"reply.content": result.Reply,
+			"reply.content": text,
 		})
-		m.sendAppText(ctx, inst, to, contextToken, result.Reply)
+		m.sendAppText(ctx, inst, to, contextToken, text)
 		span.End()
 	}
 }

--- a/internal/bot/app_dispatch.go
+++ b/internal/bot/app_dispatch.go
@@ -77,15 +77,11 @@ func (m *Manager) tryDeliverMention(inst *Instance, msg provider.InboundMessage,
 	if !strings.HasPrefix(trimmed, "@") {
 		return false
 	}
-	parts := strings.SplitN(trimmed[1:], " ", 2)
-	handle := strings.ToLower(parts[0])
+	// Split on any Unicode whitespace — WeChat inserts U+2005 after @mentions.
+	handleRaw, text := appdelivery.SplitFirstField(trimmed[1:])
+	handle := strings.ToLower(handleRaw)
 	if handle == "" {
 		return false
-	}
-
-	text := ""
-	if len(parts) > 1 {
-		text = strings.TrimSpace(parts[1])
 	}
 
 	installation, err := m.appDisp.Store.GetInstallationByHandle(inst.DBID, handle)
@@ -97,12 +93,8 @@ func (m *Manager) tryDeliverMention(inst *Instance, msg provider.InboundMessage,
 	rootSpan.AddEvent("match_handle", map[string]any{"handle": handle, "app.name": installation.AppName})
 
 	if strings.HasPrefix(text, "/") {
-		cmdParts := strings.SplitN(text[1:], " ", 2)
-		command := strings.ToLower(cmdParts[0])
-		cmdArgs := ""
-		if len(cmdParts) > 1 {
-			cmdArgs = strings.TrimSpace(cmdParts[1])
-		}
+		cmd, cmdArgs := appdelivery.SplitFirstField(text[1:])
+		command := strings.ToLower(cmd)
 		event := appdelivery.NewEvent("command", map[string]any{
 			"command": command, "text": cmdArgs,
 			"sender": map[string]any{"id": msg.Sender, "role": "user"},

--- a/internal/bot/app_dispatch_test.go
+++ b/internal/bot/app_dispatch_test.go
@@ -344,3 +344,57 @@ func TestDeliverToApps_BuiltinHandlerWhenNoWS(t *testing.T) {
 		t.Error("builtin handler was not called when no WS connection was active")
 	}
 }
+
+// TestTryDeliverMention_UnicodeWhitespace locks the third parsing path: an
+// @handle followed by WeChat's U+2005 separator must still route to the
+// installation. This is the root cause behind issue #248 — @handle "didn't
+// work" in WeChat (which inserts U+2005 after a mention) so users fell back to /.
+func TestTryDeliverMention_UnicodeWhitespace(t *testing.T) {
+	const (
+		botID  = "bot-mention-u2005"
+		appID  = "app-mention-u2005"
+		instID = "inst-mention-u2005"
+	)
+
+	ms := memstore.New()
+	ms.AddInstallation(&store.AppInstallation{
+		ID:      instID,
+		AppID:   appID,
+		BotID:   botID,
+		Handle:  "echo-work",
+		AppSlug: "echo",
+		Enabled: true,
+	})
+
+	hub := appdelivery.NewWSHub()
+	sendCh := make(chan []byte, 4)
+	hub.Register(instID, &appdelivery.WSConn{InstID: instID, BotID: botID, Send: sendCh})
+
+	m := newTestManager(ms, hub)
+	tracer, root := newTestTracer(botID)
+	// "@echo-work" + U+2005 (FOUR-PER-EM SPACE) + "hello".
+	content := "@echo-work hello"
+	msg, p := textMessage("user-1", content)
+
+	if !m.tryDeliverMention(&Instance{DBID: botID}, msg, p, content, tracer, root) {
+		t.Fatal("tryDeliverMention returned false — @handle with U+2005 failed to route")
+	}
+
+	select {
+	case data := <-sendCh:
+		var env map[string]any
+		if err := json.Unmarshal(data, &env); err != nil {
+			t.Fatalf("unmarshal ws payload: %v", err)
+		}
+		ev, _ := env["event"].(map[string]any)
+		if ev["type"] != "message.text" {
+			t.Errorf("event type = %v, want message.text", ev["type"])
+		}
+		evData, _ := ev["data"].(map[string]any)
+		if evData["content"] != "hello" {
+			t.Errorf("content = %v, want %q", evData["content"], "hello")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out: mention event was not delivered after U+2005 split")
+	}
+}

--- a/internal/bot/app_dispatch_test.go
+++ b/internal/bot/app_dispatch_test.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -179,6 +180,74 @@ type fakeBuiltinHandler struct{ called bool }
 func (h *fakeBuiltinHandler) HandleEvent(_ *store.AppInstallation, _ *appdelivery.Event) error {
 	h.called = true
 	return nil
+}
+
+// fakeProvider captures the last outbound message for assertions.
+type fakeProvider struct {
+	sentText string
+	sentTo   string
+}
+
+func (f *fakeProvider) Name() string                                       { return "fake" }
+func (f *fakeProvider) Start(context.Context, provider.StartOptions) error { return nil }
+func (f *fakeProvider) Stop()                                              {}
+func (f *fakeProvider) Send(_ context.Context, msg provider.OutboundMessage) (string, error) {
+	f.sentText = msg.Text
+	f.sentTo = msg.Recipient
+	return "client-1", nil
+}
+func (f *fakeProvider) SendTyping(context.Context, string, string, bool) error { return nil }
+func (f *fakeProvider) GetConfig(context.Context, string, string) (*provider.BotConfig, error) {
+	return &provider.BotConfig{}, nil
+}
+func (f *fakeProvider) DownloadMedia(context.Context, *provider.Media) ([]byte, error) {
+	return nil, nil
+}
+func (f *fakeProvider) DownloadVoice(context.Context, *provider.Media, int) ([]byte, error) {
+	return nil, nil
+}
+func (f *fakeProvider) Status() string { return "connected" }
+
+// TestChannelTag covers the channel-reply prefix (issue #248): prefer handle,
+// fall back to app name, empty when neither is set, and never an "@" prefix.
+func TestChannelTag(t *testing.T) {
+	cases := []struct {
+		name string
+		inst *store.AppInstallation
+		want string
+	}{
+		{"handle preferred over app name", &store.AppInstallation{Handle: "openclaw", AppName: "OpenClaw"}, "【openclaw】 "},
+		{"fall back to app name", &store.AppInstallation{AppName: "OpenClaw"}, "【OpenClaw】 "},
+		{"empty when no name", &store.AppInstallation{}, ""},
+		{"nil installation", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := channelTag(tc.inst); got != tc.want {
+				t.Errorf("channelTag = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSendAppResult_ChannelTagPrefix verifies a webhook app's text reply is
+// prefixed with its channel tag before being sent to the user (issue #248).
+func TestSendAppResult_ChannelTagPrefix(t *testing.T) {
+	ms := memstore.New()
+	fp := &fakeProvider{}
+	m := newTestManager(ms, appdelivery.NewWSHub())
+	inst := &Instance{DBID: "bot-tag", Provider: fp}
+	installation := &store.AppInstallation{ID: "i1", Handle: "openclaw", AppName: "OpenClaw"}
+	tracer, root := newTestTracer("bot-tag")
+
+	m.sendAppResult(inst, installation, "user-9", &appdelivery.DeliveryResult{Reply: "hello there"}, tracer, root)
+
+	if want := "【openclaw】 hello there"; fp.sentText != want {
+		t.Errorf("sent text = %q, want %q", fp.sentText, want)
+	}
+	if fp.sentTo != "user-9" {
+		t.Errorf("sent to = %q, want %q", fp.sentTo, "user-9")
+	}
 }
 
 // newTestManager builds a minimal Manager for app_dispatch tests.


### PR DESCRIPTION
本 PR 处理 issue #248 的两个诉求,分两个独立 commit。

---

## Commit 1 — `@mention` 因 U+2005 分隔符无法路由(根因修复)

#248 建议把引导符 `/` 改成 `@`。排查后发现:**`@handle` 路由本就该工作,但有分词 bug 在微信里失效**,用户才退回 `/openclaw`。

微信 @ 一个名字后,客户端自动插入的是 **U+2005(FOUR-PER-EM SPACE)**(部分客户端用全角 U+3000),而 `ParseMention`/`tryDeliverMention`/`parseCommand` 都用 `strings.SplitN(x, " ", 2)` 只切半角空格 → 整段被当 handle → 查不到安装 → 路由静默失败。

**改动**:新增 `SplitFirstField`(按 `unicode.IsSpace` 切,多字节安全),替换三处分词。普通空格行为零变化。三条路径各加真实 U+2005 回归测试。

→ 修好后 `@openclaw` 在微信里直接可用,**无需把 `/` 改成 `@`**,不动现有 `/` 命令语义。

## Commit 2 — 频道回复加 `【handle】` 标签(Part 2)

#248 第 2 点:希望 channel 回复时标注是哪个 channel。webhook app/channel 的文本回复前现在加 `【handle】`(handle 缺省回退 app 名)前缀。

**为何不用字面的 `@handle` 前缀**:这是 iLink 微信**个人号**网关,无法验证它是否会把账号自己发出的消息回推成 inbound,也无法可靠区分(账号的手动消息与自动回复共用同一 wxid)。以 `@` 开头的回复一旦被回推,可能被 mention 路由再次消费 → 回环;而 `【handle】` 对 `parseCommand`/`tryDeliverMention` **完全惰性**,彻底回避回环,且无需一个不安全的自消息过滤。

**范围**:仅作用于 webhook app 回复(`sendAppResult`);builtin bridge(如飞书)自行发送,不受影响。测试覆盖 `channelTag`、加前缀的发送、以及「带标签回复对 mention/command 解析惰性」。

---

## 评审与验证
- 设计经 **Codex** 两轮 review(根因判断、`unicode.IsSpace` 修法、`【】` vs `@` 取舍、自消息过滤的不可行性)均 go;**CodeRabbit** 对 commit 1 给出 0 findings。
- `go build ./...`(除环境缺 `web/dist` 的 embed 外)、`go vet`、`internal/app` + `internal/bot` 全量测试通过,零回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved mention and slash-command parsing to correctly handle Unicode whitespace (including non-ASCII separators), ensuring handles, commands, and arguments are extracted and routed reliably.

* **Behavior Changes**
  * Text replies now include a channel/app tag prefix (non-`@`) before delivery, preventing unintended re-parsing loops.

* **Tests**
  * Added coverage for Unicode-whitespace parsing and for channel-tag prefix and inert tagged replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->